### PR TITLE
After clicking on the next page at the end ,should raise a 404

### DIFF
--- a/reader/templates/chapter.html
+++ b/reader/templates/chapter.html
@@ -114,13 +114,13 @@
                  {% if next_chapter %}
                    data-next="{{ next_chapter.get_absolute_url }}"
                  {% else %}
-                   data-next="{{ series_url }}"
+                   data-next="{{ curr_chapter.series.get_absolute_url }}"
                  {% endif %}
               {% elif curr_page.number == 1 %}
                  {% if prev_chapter %}
                    data-prev="{{ prev_chapter.get_absolute_url }}"
                  {% else %}
-                   data-prev="{{ series_url }}"
+                   data-prev="{{ curr_chapter.series.get_absolute_url }}"
                  {% endif %}
               {% endif %}>
         <i class="mi mi-spin"></i>


### PR DESCRIPTION
On clicking the page, it advances to next. On the end page it does the same thing instead of redirecting it to series so page no exceeds the length . I think that the series_url was not being passed properly . I don't know much of how urls are passed but i think this should be it , please do tell me if i'm wrong.Thanks