### PR TITLE
Modernise MangAdventure 2: Electric Boogaloo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ CSP_REPORT_URI=""
 # The percentage of requests that should report CSP violations.
 # This should be a number between 0 and 100.
 # Only required if you've installed django-csp.
-CSP_REPORT_PERCENTAGE=25
+CSP_REPORT_PERCENTAGE=5
 
 # See https://docs.sentry.io/error-reporting/quickstart/?platform=python
 # Example: "https://1b504d3328e16fdf281d1fb9516dd90b@o9876543.ingest.sentry.io/1234567"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 python:
-    version: 3.6
+    version: '3.7'
     install:
         - method: pip
           path: .

--- a/MangAdventure/__init__.py
+++ b/MangAdventure/__init__.py
@@ -1,5 +1,5 @@
 """A simple manga hosting CMS written in Django."""
 
 __license__ = 'MIT'
-__version__ = '0.7.4'
+__version__ = '0.8.0'
 __author__ = 'evangelos-ch, ObserverOfTime'

--- a/MangAdventure/__main__.py
+++ b/MangAdventure/__main__.py
@@ -1,21 +1,13 @@
 #!/usr/bin/env python3
 
-from os import environ as env
+from os import environ
 from sys import argv
 
 
-def main():
-    env.setdefault('DJANGO_SETTINGS_MODULE', 'MangAdventure.settings')
-    try:
-        from django.core.management import execute_from_command_line
-    except ImportError:
-        raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available in your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
-        )
+def run():
+    environ['DJANGO_SETTINGS_MODULE'] = 'MangAdventure.settings'
+    from django.core.management import execute_from_command_line
     execute_from_command_line(argv)
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == '__main__': run()  # noqa: E701

--- a/MangAdventure/bad_bots.py
+++ b/MangAdventure/bad_bots.py
@@ -6,6 +6,7 @@ BOTS = [
     'autoemailspider',
     'BlackWidow',
     'Boston Project',
+    'Bytespider',
     'bwh3_user_agent',
     'China Local Browse',
     'ContactBot',

--- a/MangAdventure/filters.py
+++ b/MangAdventure/filters.py
@@ -25,7 +25,7 @@ def title_filter(title: str, klass: Type[FieldListFilter] =
     """
     class _GenericFilter(klass):  # pragma: no cover
         def __new__(cls, *args, **kwargs):
-            instance = super(_GenericFilter, cls).create(*args, **kwargs)
+            instance = super().create(*args, **kwargs)
             instance.title = title
             return instance
 
@@ -48,7 +48,7 @@ def boolean_filter(title: str, param: str, names:
             self.names = names
             self.title = title
             self.parameter_name = param
-            super(_BooleanFilter, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
         def lookups(self, request, model_admin):
             return [

--- a/MangAdventure/middleware.py
+++ b/MangAdventure/middleware.py
@@ -1,5 +1,7 @@
 """Custom middleware."""
 
+from __future__ import annotations
+
 from re import MULTILINE, findall, search
 from typing import TYPE_CHECKING
 
@@ -12,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class BaseMiddleware(CommonMiddleware):
     """``CommonMiddleware`` with custom patches."""
-    def __call__(self, request: 'HttpRequest') -> 'HttpResponse':
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         """
         Patched to allow :const:`blocked user agents
         <MangAdventure.settings.DISALLOWED_USER_AGENTS>`
@@ -29,10 +31,10 @@ class BaseMiddleware(CommonMiddleware):
 
 class PreloadMiddleware:
     """Middleware that allows for preloading resources."""
-    def __init__(self, get_response: 'Callable[[HttpRequest], HttpResponse]'):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
 
-    def __call__(self, request: 'HttpRequest') -> 'HttpResponse':
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         """
         Add a ``Link`` header with preloadable resources to the response.
 

--- a/MangAdventure/search.py
+++ b/MangAdventure/search.py
@@ -1,5 +1,7 @@
 """Functions used for searching."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List, NamedTuple, Tuple
 
 from django.db.models import Count, Max, Q
@@ -41,7 +43,7 @@ class _SearchParams(NamedTuple):
         )
 
 
-def parse(request: 'HttpRequest') -> _SearchParams:
+def parse(request: HttpRequest) -> _SearchParams:
     """
     Parse a request and return a :obj:`~collections.namedtuple`
     of search parameters.
@@ -99,7 +101,7 @@ def qsfilter(params: _SearchParams) -> Q:
     return filters
 
 
-def query(params: _SearchParams) -> 'QuerySet':
+def query(params: _SearchParams) -> QuerySet:
     """
     Get a queryset of :class:`~reader.models.Series`
     from the given search parameters.
@@ -117,7 +119,7 @@ def query(params: _SearchParams) -> 'QuerySet':
     ).filter(qsfilter(params) & Q(chapter_count__gt=0)).distinct()
 
 
-def get_response(request: 'HttpRequest') -> 'QuerySet':
+def get_response(request: HttpRequest) -> QuerySet:
     """
     Get a queryset of :class:`~reader.models.Series` from the given request.
 

--- a/MangAdventure/settings.py
+++ b/MangAdventure/settings.py
@@ -85,7 +85,6 @@ MIDDLEWARE = [
     'django.middleware.http.ConditionalGetMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
@@ -377,14 +376,6 @@ DEFAULT_FROM_EMAIL = env['EMAIL_ADDRESS']
 DISALLOWED_USER_AGENTS = [re.compile(re.escape(b), re.I) for b in BOTS]
 DISALLOWED_USER_AGENTS.append(re.compile('^$'))  # empty UA
 
-#: Set the ``HttpOnly`` flag on the CSRF cookie.
-#: See :setting:`CSRF_COOKIE_HTTP_ONLY`.
-CSRF_COOKIE_HTTP_ONLY = True
-
-#: Prevent the CSRF cookie from being sent in cross-site requests.
-#: See :setting:`CSRF_COOKIE_SAMESITE`.
-CSRF_COOKIE_SAMESITE = 'Strict'
-
 #: Prevent the session cookie from being sent in cross-site requests.
 #: See :setting:`SESSION_COOKIE_SAMESITE`.
 SESSION_COOKIE_SAMESITE = 'Strict'
@@ -400,10 +391,6 @@ if env.bool('HTTPS', True):
     #: Redirect all non-HTTPS requests to HTTPS.
     #: See :setting:`SECURE_SSL_REDIRECT`.
     SECURE_SSL_REDIRECT = True
-
-    #: Set the ``X-XSS-Protection: 1; mode=block`` header.
-    #: See :setting:`SECURE_BROWSER_XSS_FILTER`.
-    SECURE_BROWSER_XSS_FILTER = True
 
     #: Set the ``X-Content-Type-Options: nosniff`` header.
     #: See :setting:`SECURE_CONTENT_TYPE_NOSNIFF`.
@@ -422,18 +409,12 @@ if env.bool('HTTPS', True):
     #: See :setting:`SESSION_COOKIE_SECURE`.
     SESSION_COOKIE_SECURE = True
 
-    #: Use a secure cookie for the CSRF cookie.
-    #: See :setting:`CSRF_COOKIE_SECURE`.
-    CSRF_COOKIE_SECURE = True
-
     #: The default protocol used when generating account URLs.
     #: See :auth:`ACCOUNT_DEFAULT_HTTP_PROTOCOL <configuration.html>`.
     ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
 
 # Optional django-csp module
 if find_spec('csp'):
-    MIDDLEWARE.append('csp.middleware.CSPMiddleware')
-
     #: Set the :csp:`default-src` CSP directive.
     CSP_DEFAULT_SRC = ("'none'",)
 
@@ -472,10 +453,12 @@ if find_spec('csp'):
     CSP_REPORT_URI = env.list('CSP_REPORT_URI')
 
     if CSP_REPORT_URI:
-        MIDDLEWARE[-1] = 'csp.contrib.rate_limiting.RateLimitedCSPMiddleware'
+        MIDDLEWARE.append('csp.contrib.rate_limiting.RateLimitedCSPMiddleware')
 
         #: Percentage of requests that should see the ``report-uri`` directive.
         CSP_REPORT_PERCENTAGE = env.float('CSP_REPORT_PERCENTAGE', 1.0) / 100
+    else:
+        MIDDLEWARE.append('csp.middleware.CSPMiddleware')
 
     #: URLs beginning with any of these will not get the CSP headers.
     CSP_EXCLUDE_URL_PREFIXES = (

--- a/MangAdventure/templates/account/email_confirm.html
+++ b/MangAdventure/templates/account/email_confirm.html
@@ -21,7 +21,6 @@
       </div>
       {% url 'account_confirm_email' confirmation.key as confirm_url %}
       <form method="POST" action="{{ confirm_url }}">
-        {% csrf_token %}
         <input class="button" type="submit" value="Confirm">
       </form>
     {% else %}

--- a/MangAdventure/templates/account/login.html
+++ b/MangAdventure/templates/account/login.html
@@ -26,7 +26,6 @@
         <div class="error">{{ error }}</div>
       {% endfor %}
       <form method="POST" action="{% url 'account_login' %}">
-        {% csrf_token %}
         <div class="field">
           <label for="login">{{ form.login.label }}:</label>
           <input placeholder="{{ form.login.field.widget.attrs.placeholder }}"

--- a/MangAdventure/templates/account/login.html
+++ b/MangAdventure/templates/account/login.html
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
-{% load account socialaccount user_tags %}
+{% load account user_tags %}
 {% block head_extras %}
   {% if request.user.is_authenticated %}
     <meta http-equiv="Refresh" content="1; url={% url 'user_profile' %}?id={{ request.user.id }}">
@@ -59,8 +59,8 @@
         Don't have an account? Click <a href="{{ signup_url }}" rel="nofollow">here</a> to sign up.
       </section>
       <section id="oauth">
-        {% get_providers as socialaccount_providers %}
-        {% for provider in socialaccount_providers|available %}
+        {% get_oauth_providers as oauth_providers %}
+        {% for provider in oauth_providers %}
           {% if forloop.first %}<div id="oauth-or">Or, sign in with:</div>{% endif %}
           <a title="{{ provider.name }}" class="provider main-fg"
              rel="noopener nofollow" href="{% provider_login_url provider.id %}">

--- a/MangAdventure/templates/account/password_reset.html
+++ b/MangAdventure/templates/account/password_reset.html
@@ -13,7 +13,6 @@
   <article class="user-action password-reset" id="password-reset-form">
     <div>Enter your e-mail address and we will send you a link to reset your password.</div>
     <form method="POST" action="{% url 'account_reset_password' %}">
-      {% csrf_token %}
       {% for item in form %}
         <div class="field">
           <label for="{{ item.name }}">{{ item.label }}</label>

--- a/MangAdventure/templates/account/password_reset_from_key.html
+++ b/MangAdventure/templates/account/password_reset_from_key.html
@@ -13,7 +13,6 @@
       {% if form %}
         <article class="user-action password-reset" id="password-reset-new">
           <form method="POST" action="{{ action_url }}">
-            {% csrf_token %}
             {% for item in form %}
               <div class="field">
                 <label for="{{ item.name }}">{{ item.label }}</label>

--- a/MangAdventure/templates/account/signup.html
+++ b/MangAdventure/templates/account/signup.html
@@ -12,7 +12,6 @@
   <h1 class="text-shadow alter-bg">Sign up</h1>
   <article class="user-action" id="sign-up">
     <form method="POST" action="{% url 'account_signup' %}">
-      {% csrf_token %}
       {% for item in form %}
         <div class="field">
           <label for="{{ item.name }}">{{ item.label }}</label>

--- a/MangAdventure/templates/account/signup.html
+++ b/MangAdventure/templates/account/signup.html
@@ -1,5 +1,5 @@
 {% extends 'layout.html' %}
-{% load socialaccount user_tags %}
+{% load account user_tags %}
 {% block title %}
   <meta name="title" content="Sign up">
   <meta name="og:title" content="Sign up - {{ config.NAME }}">
@@ -32,8 +32,8 @@
       <input class="button" type="submit" value="Register">
     </form>
     <section id="oauth">
-      {% get_providers as socialaccount_providers %}
-      {% for provider in socialaccount_providers|available %}
+      {% get_oauth_providers as oauth_providers %}
+      {% for provider in oauth_providers %}
         {% if forloop.first %}<div id="oauth-or">Or, sign up with:</div>{% endif %}
         <a title="{{ provider.name }}" class="provider main-fg"
            rel="noopener nofollow" href="{% provider_login_url provider.id %}">

--- a/MangAdventure/templates/layout.html
+++ b/MangAdventure/templates/layout.html
@@ -81,7 +81,7 @@
     <header id="header">
       {% cache 604800 logo %}
         <a id="home" href="{% url 'index' %}">
-          <img id="logo" src="{{ config.LOGO }}"></img>
+          <img id="logo" alt="Logo" src="{{ config.LOGO }}">
         </a>
       {% endcache %}
       <nav id="navig">
@@ -131,7 +131,6 @@
               </li>
               <li class="dropdown-element">
                 <form action="{% url 'account_logout' %}" method="POST">
-                  {% csrf_token %}
                   <input type="hidden" name="next" value="{{ request.path }}">
                   <button type="submit" class="logout-btn">
                     <span>Logout</span><i class="mi mi-logout" aria-hidden="true"></i>

--- a/MangAdventure/tests/settings.py
+++ b/MangAdventure/tests/settings.py
@@ -53,7 +53,6 @@ MIDDLEWARE = [
     'django.middleware.http.ConditionalGetMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.redirects.middleware.RedirectFallbackMiddleware',
@@ -193,10 +192,6 @@ DEFAULT_FROM_EMAIL = 'evangelos-ch@users.noreply.github.com'
 
 DISALLOWED_USER_AGENTS = [re.compile(re.escape(b), re.I) for b in BOTS]
 DISALLOWED_USER_AGENTS.append(re.compile('^$'))  # empty UA
-
-CSRF_COOKIE_HTTP_ONLY = True
-
-CSRF_COOKIE_SAMESITE = 'Strict'
 
 SESSION_COOKIE_SAMESITE = 'Strict'
 

--- a/MangAdventure/validators.py
+++ b/MangAdventure/validators.py
@@ -1,5 +1,7 @@
 """Custom validators."""
 
+from __future__ import annotations
+
 from io import BytesIO
 from os import remove
 from typing import Any
@@ -14,7 +16,7 @@ from django.utils.deconstruct import deconstructible
 from PIL import Image
 
 
-def _remove_file(file: 'File'):
+def _remove_file(file: File):
     try:
         remove(file.path)
     except FileNotFoundError:
@@ -36,7 +38,7 @@ class FileSizeValidator:
     def __init__(self, max_mb: int = 10):
         self.max_mb = max_mb
 
-    def __call__(self, file: 'File'):
+    def __call__(self, file: File):
         """
         Call the validator on the given file.
 
@@ -74,7 +76,7 @@ class FileSizeValidator:
         return hash(self.code) | self.max_mb
 
 
-def zipfile_validator(file: 'File'):
+def zipfile_validator(file: File):
     """
     Validate a zip file:
 

--- a/MangAdventure/widgets.py
+++ b/MangAdventure/widgets.py
@@ -28,7 +28,7 @@ class TinyMCE(Textarea):
             if key.startswith('mce_'):
                 mce_attrs[key[4:]] = attrs.pop(key)
         attrs['data-tinymce-config'] = dumps(mce_attrs)
-        super(TinyMCE, self).__init__(attrs)
+        super().__init__(attrs)
 
     class Media:
         extend = False

--- a/api/v1/response.py
+++ b/api/v1/response.py
@@ -1,5 +1,7 @@
 """Convenience classes and functions for API responses."""
 
+from __future__ import annotations
+
 from functools import wraps
 from typing import TYPE_CHECKING, Tuple
 
@@ -30,16 +32,16 @@ class JsonError(JsonResponse):
 
 
 def require_methods_api(allowed_methods: Tuple[str, ...] =
-                        ('GET', 'HEAD')) -> 'Callable':
+                        ('GET', 'HEAD')) -> Callable:
     """
     | Decorator to make an API view only accept particular request methods.
     | Based on :func:`django.views.decorators.http.require_http_request`.
 
     :param allowed_methods: The allowed request methods.
     """
-    def decorator(func: 'Callable') -> 'Callable':
+    def decorator(func: Callable) -> Callable:
         @wraps(func)
-        def inner(request: 'HttpRequest', *args, **kwargs) -> JsonError:
+        def inner(request: HttpRequest, *args, **kwargs) -> JsonError:
             if request.method not in allowed_methods:
                 response = JsonError('Method not allowed', 405)
                 response['Allow'] = ', '.join(allowed_methods)
@@ -54,14 +56,14 @@ def require_methods_api(allowed_methods: Tuple[str, ...] =
     return decorator
 
 
-def deprecate_api(func: 'Callable') -> 'Callable':
+def deprecate_api(func: Callable) -> Callable:
     """Decorator used to denote that the API is deprecated."""
     @wraps(func)
     def inner(*args, **kwargs):
         if not settings.CONFIG['ENABLE_API_V1']:  # pragma: no cover
             return HttpResponseGone('Use API v2 instead.')
         response = func(*args, **kwargs)
-        response['Warning'] = '299 MangAdventure/0.7.4 "Deprecated API"'
+        response['Warning'] = '299 MangAdventure/0.8.0 "Deprecated API"'
         return response
     return inner
 

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -11,7 +11,6 @@ from django.http import JsonResponse
 from django.utils import timezone as tz
 from django.utils.http import http_date
 from django.views.decorators.cache import cache_control
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import last_modified
 
 from MangAdventure.search import get_response
@@ -161,7 +160,6 @@ def _group_response(request: HttpRequest, _group: Group) -> Dict:
     return response
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @last_modified(_latest)
@@ -201,7 +199,6 @@ def all_releases(request: HttpRequest) -> JsonResponse:
     return JsonResponse(response, safe=False)
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @last_modified(_latest)
@@ -220,7 +217,6 @@ def all_series(request: HttpRequest) -> JsonResponse:
     ], safe=False)
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @last_modified(_latest)
@@ -241,7 +237,6 @@ def series(request: HttpRequest, slug: str) -> JsonResponse:
     return JsonResponse(_series_response(request, _series))
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @last_modified(_latest)
@@ -267,7 +262,6 @@ def volume(request: HttpRequest, slug: str, vol: int) -> JsonResponse:
     return JsonResponse(_volume_response(request, chapters))
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @last_modified(_latest)
@@ -298,7 +292,6 @@ def _is_author(request: HttpRequest) -> bool:
     return request.path[:16] == '/api/v1/authors'
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
@@ -319,7 +312,6 @@ def all_people(request: HttpRequest) -> JsonResponse:
     ], safe=False)
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
@@ -342,7 +334,6 @@ def person(request: HttpRequest, p_id: int) -> JsonResponse:
     return JsonResponse(_person_response(request, _person))
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
@@ -362,7 +353,6 @@ def all_groups(request: HttpRequest) -> JsonResponse:
     ], safe=False)
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
@@ -384,7 +374,6 @@ def group(request: HttpRequest, g_id: int) -> JsonResponse:
     return JsonResponse(_group_response(request, _group))
 
 
-@csrf_exempt
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)

--- a/api/v1/views.py
+++ b/api/v1/views.py
@@ -1,5 +1,7 @@
 """The views of the api.v1 app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from django.conf import settings
@@ -26,9 +28,9 @@ if TYPE_CHECKING:  # pragma: no cover
     Person = Union[Author, Artist]
 
 
-def _latest(request: 'HttpRequest', slug: Optional[str] = None,
+def _latest(request: HttpRequest, slug: Optional[str] = None,
             vol: Optional[int] = None, num: Optional[float] = None
-            ) -> 'Optional[datetime]':
+            ) -> Optional[datetime]:
     try:
         if slug is None:
             q = Q(chapters__published__lte=tz.now())
@@ -51,7 +53,7 @@ def _latest(request: 'HttpRequest', slug: Optional[str] = None,
         return None
 
 
-def _chapter_response(request: 'HttpRequest', _chapter: Chapter) -> Dict:
+def _chapter_response(request: HttpRequest, _chapter: Chapter) -> Dict:
     url = request.build_absolute_uri(_chapter.get_absolute_url())
     return {
         'url': url,
@@ -65,7 +67,7 @@ def _chapter_response(request: 'HttpRequest', _chapter: Chapter) -> Dict:
     }
 
 
-def _volume_response(request: 'HttpRequest',
+def _volume_response(request: HttpRequest,
                      chapters: Iterable[Chapter]) -> Dict:
     return {
         f'{c.number:g}': _chapter_response(request, c)
@@ -73,7 +75,7 @@ def _volume_response(request: 'HttpRequest',
     }
 
 
-def _series_response(request: 'HttpRequest', _series: Series) -> Dict:
+def _series_response(request: HttpRequest, _series: Series) -> Dict:
     response = {
         'slug': _series.slug,
         'title': _series.title,
@@ -102,7 +104,7 @@ def _series_response(request: 'HttpRequest', _series: Series) -> Dict:
     return response
 
 
-def _person_response(request: 'HttpRequest', _person: 'Person') -> Dict:
+def _person_response(request: HttpRequest, _person: Person) -> Dict:
     response = {
         'id': _person.id,
         'name': _person.name,
@@ -118,7 +120,7 @@ def _person_response(request: 'HttpRequest', _person: 'Person') -> Dict:
     return response
 
 
-def _member_response(request: 'HttpRequest', _member: Member) -> Dict:
+def _member_response(request: HttpRequest, _member: Member) -> Dict:
     return {
         'id': _member.id,
         'name': _member.name,
@@ -128,7 +130,7 @@ def _member_response(request: 'HttpRequest', _member: Member) -> Dict:
     }
 
 
-def _group_response(request: 'HttpRequest', _group: Group) -> Dict:
+def _group_response(request: HttpRequest, _group: Group) -> Dict:
     logo = ''
     if _group.logo:
         logo = request.build_absolute_uri(_group.logo.url)
@@ -164,7 +166,7 @@ def _group_response(request: 'HttpRequest', _group: Group) -> Dict:
 @require_methods_api()
 @last_modified(_latest)
 @cache_control(public=True, max_age=600, must_revalidate=True)
-def all_releases(request: 'HttpRequest') -> JsonResponse:
+def all_releases(request: HttpRequest) -> JsonResponse:
     """
     View that serves all the releases in a JSON array.
 
@@ -204,7 +206,7 @@ def all_releases(request: 'HttpRequest') -> JsonResponse:
 @require_methods_api()
 @last_modified(_latest)
 @cache_control(public=True, max_age=600, must_revalidate=True)
-def all_series(request: 'HttpRequest') -> JsonResponse:
+def all_series(request: HttpRequest) -> JsonResponse:
     """
     View that serves all the series in a JSON array.
 
@@ -223,7 +225,7 @@ def all_series(request: 'HttpRequest') -> JsonResponse:
 @require_methods_api()
 @last_modified(_latest)
 @cache_control(public=True, max_age=600, must_revalidate=True)
-def series(request: 'HttpRequest', slug: str) -> JsonResponse:
+def series(request: HttpRequest, slug: str) -> JsonResponse:
     """
     View that serves a single series as a JSON object.
 
@@ -244,7 +246,7 @@ def series(request: 'HttpRequest', slug: str) -> JsonResponse:
 @require_methods_api()
 @last_modified(_latest)
 @cache_control(public=True, max_age=600, must_revalidate=True)
-def volume(request: 'HttpRequest', slug: str, vol: int) -> JsonResponse:
+def volume(request: HttpRequest, slug: str, vol: int) -> JsonResponse:
     """
     View that serves a single volume as a JSON object.
 
@@ -270,7 +272,7 @@ def volume(request: 'HttpRequest', slug: str, vol: int) -> JsonResponse:
 @require_methods_api()
 @last_modified(_latest)
 @cache_control(public=True, max_age=600, must_revalidate=True)
-def chapter(request: 'HttpRequest', slug: str,
+def chapter(request: HttpRequest, slug: str,
             vol: int, num: float) -> JsonResponse:
     """
     View that serves a single chapter as a JSON object.
@@ -292,7 +294,7 @@ def chapter(request: 'HttpRequest', slug: str,
     return JsonResponse(_chapter_response(request, _chapter))
 
 
-def _is_author(request: 'HttpRequest') -> bool:
+def _is_author(request: HttpRequest) -> bool:
     return request.path[:16] == '/api/v1/authors'
 
 
@@ -300,7 +302,7 @@ def _is_author(request: 'HttpRequest') -> bool:
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
-def all_people(request: 'HttpRequest') -> JsonResponse:
+def all_people(request: HttpRequest) -> JsonResponse:
     """
     View that serves all the authors/artists in a JSON array.
 
@@ -321,7 +323,7 @@ def all_people(request: 'HttpRequest') -> JsonResponse:
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
-def person(request: 'HttpRequest', p_id: int) -> JsonResponse:
+def person(request: HttpRequest, p_id: int) -> JsonResponse:
     """
     View that serves a single author/artist as a JSON object.
 
@@ -344,7 +346,7 @@ def person(request: 'HttpRequest', p_id: int) -> JsonResponse:
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
-def all_groups(request: 'HttpRequest') -> JsonResponse:
+def all_groups(request: HttpRequest) -> JsonResponse:
     """
     View that serves all the groups in a JSON array.
 
@@ -364,7 +366,7 @@ def all_groups(request: 'HttpRequest') -> JsonResponse:
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
-def group(request: 'HttpRequest', g_id: int) -> JsonResponse:
+def group(request: HttpRequest, g_id: int) -> JsonResponse:
     """
     View that serves a single group as a JSON object.
 
@@ -386,7 +388,7 @@ def group(request: 'HttpRequest', g_id: int) -> JsonResponse:
 @deprecate_api
 @require_methods_api()
 @cache_control(public=True, max_age=1800, must_revalidate=True)
-def categories(request: 'HttpRequest') -> JsonResponse:
+def categories(request: HttpRequest) -> JsonResponse:
     """
     View that serves all the categories in a JSON array.
 

--- a/api/v2/auth.py
+++ b/api/v2/auth.py
@@ -1,5 +1,7 @@
 """Authentication & authorization utilities."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from rest_framework.authentication import TokenAuthentication
@@ -16,7 +18,7 @@ class ApiKeyAuthentication(TokenAuthentication):
     keyword = 'X-API-Key'
     model = ApiKey
 
-    def authenticate(self, request: 'Request') -> Optional[Tuple]:
+    def authenticate(self, request: Request) -> Optional[Tuple]:
         token = request.headers.get(
             self.keyword, request.GET.get('api_key')
         )

--- a/api/v2/views.py
+++ b/api/v2/views.py
@@ -1,5 +1,7 @@
 """The custom views of the api.v2 app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from django.http import HttpResponsePermanentRedirect
@@ -24,7 +26,7 @@ openapi = cache_control(public=True, max_age=1296000, immutable=True)(
 )
 
 
-def redoc_redirect(request: 'HttpRequest') -> HttpResponsePermanentRedirect:
+def redoc_redirect(request: HttpRequest) -> HttpResponsePermanentRedirect:
     """Redirect to the ReDoc demo with our schema."""
     url = request.build_absolute_uri(reverse('api:v2:schema'))
     return HttpResponsePermanentRedirect(
@@ -32,7 +34,7 @@ def redoc_redirect(request: 'HttpRequest') -> HttpResponsePermanentRedirect:
     )
 
 
-def swagger_redirect(request: 'HttpRequest') -> HttpResponsePermanentRedirect:
+def swagger_redirect(request: HttpRequest) -> HttpResponsePermanentRedirect:
     """Redirect to the Swagger generator with our schema."""
     url = request.build_absolute_uri(reverse('api:v2:schema'))
     return HttpResponsePermanentRedirect(

--- a/config/apps.py
+++ b/config/apps.py
@@ -22,7 +22,7 @@ class SiteConfig(AppConfig):
 
     def ready(self):
         """Configure the site when the app is ready."""
-        super(SiteConfig, self).ready()
+        super().ready()
 
         if 'django_site' in connection.introspection.table_names():
             self._configure()

--- a/config/context_processors.py
+++ b/config/context_processors.py
@@ -1,5 +1,7 @@
 """Custom context processors."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict
 
 from django.conf import settings
@@ -11,14 +13,16 @@ if TYPE_CHECKING:  # pragma: no cover
     from django.http import HttpRequest
 
 
-def extra_settings(request: 'HttpRequest') -> Dict:
+def extra_settings(request: HttpRequest) -> Dict:
     """
-    Context processor which defines some settings variables.
+    Context processor which defines some settings variables & schemas.
 
     * ``MANGADV_VERSION``: The current version of MangAdventure.
     * ``PAGE_URL``: The complete absolute URI of the request.
     * ``CANON_URL``: The absolute URI of the request minus the query string.
     * ``config``: A reference to :const:`MangAdventure.settings.CONFIG`.
+    * ``searchbox``: Searchbox JSON-LD schema.
+    * ``organization``: Organization JSON-LD schema.
 
     :param request: The current HTTP request.
 

--- a/config/management/commands/fs2import.py
+++ b/config/management/commands/fs2import.py
@@ -1,5 +1,7 @@
 """FoolSlide2 importer."""
 
+from __future__ import annotations
+
 from io import StringIO
 from os.path import abspath, join
 from typing import TYPE_CHECKING
@@ -23,7 +25,7 @@ class Command(BaseCommand):
     """Command used to import data from a FoolSlide2 installation."""
     help = 'Imports data from FoolSlide2.'
 
-    def add_arguments(self, parser: 'ArgumentParser'):
+    def add_arguments(self, parser: ArgumentParser):
         """
         Add arguments to the command.
 
@@ -181,18 +183,18 @@ class Command(BaseCommand):
         self._print_success('Successfully imported FoolSlide2 data.')
 
     @staticmethod
-    def _get_element(tables: 'Elems', name: str) -> 'Elems':
+    def _get_element(tables: Elems, name: str) -> Elems:
         return list(filter(
             lambda t: t.attrib['name'].endswith(name), tables
         ))
 
     @staticmethod
-    def _get_column(table: 'Elem', name: str) -> str:
+    def _get_column(table: Elem, name: str) -> str:
         elem = table.find(f'column[@name="{name}"]')
         return getattr(elem, 'text', None) or ''
 
     @staticmethod
-    def _sort_children(tables: 'Elems', name: str) -> 'Elems':
+    def _sort_children(tables: Elems, name: str) -> Elems:
         return sorted(tables, key=lambda p: Command._get_column(p, name))
 
     def _print(self, text: str, **kwargs):

--- a/config/management/commands/logs.py
+++ b/config/management/commands/logs.py
@@ -1,3 +1,7 @@
+"""Admin logs command"""
+
+from __future__ import annotations
+
 from sys import stdout
 from typing import TYPE_CHECKING
 
@@ -13,7 +17,7 @@ class Command(BaseCommand):
     """Command used to view admin logs."""
     help = 'Outputs admin logs to a file or stdout.'
 
-    def add_arguments(self, parser: 'ArgumentParser'):
+    def add_arguments(self, parser: ArgumentParser):
         """
         Add arguments to the command.
 

--- a/config/templatetags/custom_tags.py
+++ b/config/templatetags/custom_tags.py
@@ -88,6 +88,7 @@ def get_type(link: str) -> str:
             '.jpg': 'image/jpeg',
             '.jpm': 'image/jpm',
             '.jpx': 'image/jpx',
+            '.jxl': 'image/jxl',
             '.jxr': 'image/jxr',
             '.jxs': 'image/jxs',
             '.png': 'image/png',

--- a/config/templatetags/flatpage_tags.py
+++ b/config/templatetags/flatpage_tags.py
@@ -1,5 +1,7 @@
 """Template tags used by the flatpage template."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from django.template.defaultfilters import register
@@ -14,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @register.filter
-def breadcrumbs_ld(request: 'HttpRequest', page: 'FlatPage') -> str:
+def breadcrumbs_ld(request: HttpRequest, page: FlatPage) -> str:
     """
     Create a JSON-LD ``<script>`` with the page's breadcrumbs.
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,16 +13,10 @@ if find_spec('csp'):  # pragma: no cover
         img_src="https:"
     )(flatpage)
 
-info_page.__doc__ = """
-| Alias for :func:`django.contrib.flatpages.views.flatpage`.
-| If ``django-csp`` is installed, this is configured
-  to allow custom styles & images in the page.
-"""
-
 #: The URL patterns of the config app.
 urlpatterns = [
     path('info/', info_page, {'url': '/info/'}, name='info'),
     path('privacy/', info_page, {'url': '/privacy/'}, name='privacy'),
 ]
 
-__all__ = ['info_page', 'urlpatterns']
+__all__ = ['urlpatterns']

--- a/docs/_ext/mangadventure_patches.py
+++ b/docs/_ext/mangadventure_patches.py
@@ -46,7 +46,7 @@ def _get_module(cls: Optional[Type]) -> str:
 def _patched_add_directive_header(self: DataDocumenter, sig: str):
     # Don't document values of settings
     if self.modname == 'MangAdventure.settings':
-        DataDocumenter.__base__.add_directive_header(self, sig)
+        super(DataDocumenter, self).add_directive_header(sig)
     else:
         self._original_add_directive_header(sig)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ v0.8.0
 
 * Dropped support for Python 3.6
 * Made ``Group.id`` auto-increment
+* Removed CSRF token
 
 v0.7.4
 ^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ v0.8.0
 ^^^^^^
 
 * Dropped support for Python 3.6
-
+* Made ``Group.id`` auto-increment
 
 v0.7.4
 ^^^^^^

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+v0.8.0
+^^^^^^
+
+* Dropped support for Python 3.6
+
+
 v0.7.4
 ^^^^^^
 

--- a/docs/compatibility.rst
+++ b/docs/compatibility.rst
@@ -11,9 +11,9 @@ Python
      - Compatibility
    * - <=2.7
      - Incompatible
-   * - 3.0 - 3.5
+   * - 3.0 - 3.6
      - Incompatible
-   * - 3.6 - 3.9
+   * - 3.7 - 3.10
      - Compatible
 
 Databases
@@ -117,25 +117,25 @@ Browsers
      - Versions
    * - | |Chrome|
        | Chrome
-     - 49+
+     - 51+
    * - | |FF|
        | Firefox
-     - 44+
+     - 60+
    * - | |IE|
        | Internet Explorer
      - |X|
    * - | |Edge|
        | Edge
-     - 15+
+     - 16+
    * - | |Safari|
        | Safari
-     - 11+
+     - 14.1+
    * - | |Opera|
        | Opera
-     - 37+
+     - 39+
    * - | |iOS|
        | iOS Safari
-     - 11+
+     - 13+
    * - | |Android|
        | Android Browser
      - |X|
@@ -143,31 +143,31 @@ Browsers
        | Samsung Internet
      - 5+
 
-.. |Chrome| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/chrome/chrome_32x32.png
+.. |Chrome| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/chrome/chrome_32x32.png
    :alt: Chrome
 
-.. |FF| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/firefox/firefox_32x32.png
+.. |FF| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/firefox/firefox_32x32.png
    :alt: Firefox
 
-.. |IE| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/archive/internet-explorer_9-11/internet-explorer_9-11_32x32.png
+.. |IE| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/archive/internet-explorer_9-11/internet-explorer_9-11_32x32.png
    :alt: Internet Explorer
 
-.. |Edge| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/edge/edge_32x32.png
+.. |Edge| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/edge/edge_32x32.png
    :alt: Edge
 
-.. |Safari| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/safari/safari_32x32.png
+.. |Safari| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/safari/safari_32x32.png
    :alt: Safari
 
-.. |Opera| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/opera/opera_32x32.png
+.. |Opera| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/opera/opera_32x32.png
    :alt: Opera
 
-.. |Samsung| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/samsung-internet/samsung-internet_32x32.png
+.. |Samsung| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/samsung-internet/samsung-internet_32x32.png
    :alt: Samsung Internet
 
-.. |Android| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/archive/android/android_32x32.png
+.. |Android| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/archive/android/android_32x32.png
    :alt: Android Browser
 
-.. |iOS| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/69.0.4/safari-ios/safari-ios_32x32.png
+.. |iOS| image:: https://cdnjs.cloudflare.com/ajax/libs/browser-logos/70.4.0/safari-ios/safari-ios_32x32.png
    :alt: iOS Safari
 
 .. |X| unicode:: U+2716

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 language = 'en'
 pygments_style = 'manni'
-needs_sphinx = '3.3'
+needs_sphinx = '3.5'
 
 
 # -- InterSphinx & extlinks configuration --
@@ -45,7 +45,7 @@ _mdn = 'https://developer.mozilla.org/en-US/docs/Web/'
 
 intersphinx_mapping = {
     'django': (_django, f'{_django}_objects/'),
-    'python': ('https://docs.python.org/3.6/', None),
+    'python': ('https://docs.python.org/3.7/', None),
 }
 
 extlinks = {

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,7 +38,7 @@ Finally, install MangAdventure inside the activated virtualenv:
 
 .. code-block:: shell
 
-   pip install -e "git+https://github.com/mangadventure/MangAdventure@v0.7.4#egg=mangadventure"
+   pip install -e "git+https://github.com/mangadventure/MangAdventure@v0.8.0#egg=mangadventure"
 
 MangAdventure also provides the following extras:
 
@@ -52,7 +52,7 @@ For example, you can install ``csp`` & ``uwsgi`` like so:
 
 .. code-block:: shell
 
-   pip install -e "git+https://github.com/mangadventure/MangAdventure@v0.7.4#egg=mangadventure[csp,uwsgi]"
+   pip install -e "git+https://github.com/mangadventure/MangAdventure@v0.8.0#egg=mangadventure[csp,uwsgi]"
 
 .. _MySQL database support:
    https://mysql.com/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==3.3.*
+sphinx~=3.5.4
 sphinx-rtd-theme
 sphinx-autodoc-typehints

--- a/groups/admin.py
+++ b/groups/admin.py
@@ -1,5 +1,7 @@
 """Admin models for the groups app."""
 
+from __future__ import annotations
+
 from typing import Optional
 
 from django.contrib import admin
@@ -21,9 +23,9 @@ class MemberRoleInline(admin.StackedInline):
     model = Role
     extra = 1
 
-    def get_formset(self, request: 'HttpRequest',
+    def get_formset(self, request: HttpRequest,
                     obj: Optional[Role], **kwargs
-                    ) -> 'BaseInlineFormSet':  # pragma: no cover
+                    ) -> BaseInlineFormSet:  # pragma: no cover
         formset = super().get_formset(request, obj, **kwargs)
         if request.user.is_superuser:
             return formset
@@ -44,6 +46,7 @@ class MemberAdmin(admin.ModelAdmin):
         ('roles__role', filters.related_filter('role')),
     )
 
+    @admin.display(ordering='twitter', description='twitter')
     def _twitter(self, obj: Member) -> str:
         if not obj.twitter:
             return ''
@@ -52,9 +55,7 @@ class MemberAdmin(admin.ModelAdmin):
             ' target="_blank">@{0}</a>', obj.twitter
         )
 
-    _twitter.short_description = 'twitter'
-    _twitter.admin_order_field = 'twitter'
-
+    @admin.display(ordering='reddit', description='reddit')
     def _reddit(self, obj: Member) -> str:
         if not obj.reddit:
             return ''
@@ -62,9 +63,6 @@ class MemberAdmin(admin.ModelAdmin):
             '<a href="https://reddit.com/u/{0}" rel="noopener noreferrer"'
             ' target="_blank">/u/{0}</a>', obj.reddit
         )
-
-    _reddit.short_description = 'reddit'
-    _reddit.admin_order_field = 'reddit'
 
 
 class GroupAdmin(admin.ModelAdmin):
@@ -79,8 +77,8 @@ class GroupAdmin(admin.ModelAdmin):
     )
     empty_value_display = 'N/A'
 
-    def get_form(self, request: 'HttpRequest', obj: Optional[Group]
-                 = None, change: bool = False, **kwargs) -> 'ModelForm':
+    def get_form(self, request: HttpRequest, obj: Optional[Group]
+                 = None, change: bool = False, **kwargs) -> ModelForm:
         form = super().get_form(request, obj, change, **kwargs)
         if 'manager' in form.base_fields:
             form.base_fields['manager'].initial = request.user.id
@@ -88,6 +86,7 @@ class GroupAdmin(admin.ModelAdmin):
                 form.base_fields['manager'].widget = HiddenInput()
         return form
 
+    @admin.display(description='logo')
     def image(self, obj: Group) -> str:
         """
         Get the logo of the group as an HTML ``<img>``.
@@ -98,8 +97,7 @@ class GroupAdmin(admin.ModelAdmin):
         """
         return utils.img_tag(obj.logo, 'logo', height=25)
 
-    image.short_description = 'logo'
-
+    @admin.display(ordering='website', description='website')
     def _website(self, obj: Group) -> str:
         if not obj.website:
             return ''
@@ -108,10 +106,7 @@ class GroupAdmin(admin.ModelAdmin):
             ' target="_blank">{0}</a>', obj.website
         )
 
-    _website.short_description = 'website'
-    _website.admin_order_field = 'website'
-
-    def has_change_permission(self, request: 'HttpRequest', obj:
+    def has_change_permission(self, request: HttpRequest, obj:
                               Optional[Group] = None) -> bool:
         """
         Return ``True`` if editing the object is permitted.
@@ -128,7 +123,7 @@ class GroupAdmin(admin.ModelAdmin):
             return True
         return obj.manager_id == request.user.id
 
-    def has_delete_permission(self, request: 'HttpRequest', obj:
+    def has_delete_permission(self, request: HttpRequest, obj:
                               Optional[Group] = None) -> bool:
         """
         Return ``True`` if deleting the object is permitted.

--- a/groups/feeds.py
+++ b/groups/feeds.py
@@ -1,5 +1,7 @@
 """RSS and Atom feeds for the groups app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Iterable
 
 from django.conf import settings
@@ -22,7 +24,7 @@ class GroupRSS(Feed):
     author_name = settings.CONFIG['NAME']
     item_guid_is_permalink = True
 
-    def get_object(self, request: 'HttpRequest', g_id: int) -> Group:
+    def get_object(self, request: HttpRequest, g_id: int) -> Group:
         """
         Get a ``Group`` object from the request.
 
@@ -92,7 +94,7 @@ class GroupRSS(Feed):
             desc = f'<a href="{scheme}://{domain}{url}">{desc}</a>'
         return desc
 
-    def item_pubdate(self, item: Chapter) -> 'datetime':
+    def item_pubdate(self, item: Chapter) -> datetime:
         """
         Get the publication date of the item.
 
@@ -102,7 +104,7 @@ class GroupRSS(Feed):
         """
         return item.published
 
-    def item_updateddate(self, item: Chapter) -> 'datetime':
+    def item_updateddate(self, item: Chapter) -> datetime:
         """
         Get the update date of the item.
 

--- a/groups/migrations/0003_alter_group_id.py
+++ b/groups/migrations/0003_alter_group_id.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('groups', '0002_managers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='group',
+            name='id',
+            field=models.SmallAutoField(
+                auto_created=True, primary_key=True,
+                serialize=False, verbose_name='ID'
+            ),
+        ),
+    ]

--- a/groups/models.py
+++ b/groups/models.py
@@ -7,7 +7,6 @@ from pathlib import PurePath
 
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models.functions import Coalesce
 from django.shortcuts import reverse
 
 from MangAdventure.fields import (
@@ -36,7 +35,10 @@ class _ChoiceMeta(EnumMeta):
 class Group(models.Model):
     """A model representing a group."""
     #: The group's ID.
-    id = models.SmallIntegerField(primary_key=True, auto_created=True)
+    id = models.SmallAutoField(
+        primary_key=True, auto_created=True,
+        serialize=False, verbose_name='ID'
+    )
     #: The group's name.
     name = models.CharField(max_length=100, help_text="The group's name.")
     #: The group's website.
@@ -98,18 +100,6 @@ class Group(models.Model):
                  :const:`~MangAdventure.settings.MEDIA_ROOT`.
         """
         return PurePath('groups', str(self.id))
-
-    @property
-    def _increment(self) -> int:
-        return Group.objects.aggregate(
-            last=Coalesce(models.Max('id'), 0) + 1
-        )['last']
-
-    def save(self, *args, **kwargs):
-        """Save the current instance."""
-        if not self.id:
-            self.id = self._increment
-        super(Group, self).save(*args, **kwargs)
 
     def __str__(self) -> str:
         """

--- a/groups/models.py
+++ b/groups/models.py
@@ -1,5 +1,7 @@
 """Database models for the groups app."""
 
+from __future__ import annotations
+
 from enum import Enum, EnumMeta
 from pathlib import PurePath
 
@@ -15,7 +17,7 @@ from MangAdventure.storage import CDNStorage
 from MangAdventure.validators import FileSizeValidator
 
 
-def _logo_uploader(obj: 'Group', name: str) -> str:
+def _logo_uploader(obj: Group, name: str) -> str:
     name = f'logo.{name.split(".")[-1]}'
     return str(obj.get_directory() / name)
 

--- a/groups/templatetags/group_tags.py
+++ b/groups/templatetags/group_tags.py
@@ -1,5 +1,7 @@
 """Template tags of the groups app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from django.template.defaultfilters import register
@@ -9,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @register.filter
-def group_roles(member: 'Member', group: 'Group') -> str:
+def group_roles(member: Member, group: Group) -> str:
     """
     Get the roles of the member within the group.
 

--- a/groups/tests/test_models.py
+++ b/groups/tests/test_models.py
@@ -13,7 +13,7 @@ class TestGroup(GroupsTestBase):
         return Group.objects.create(
             name='my group', website='https://test.com/',
             description='My test group', email='scan@test.com',
-            discord='https://discord.gg/abcdefg',
+            id=1, discord='https://discord.gg/abcdefg',
             twitter='MyTwitter', irc='#epicspeedscans',
             reddit='/r/epicspeedscans', logo=get_test_image()
         )
@@ -24,7 +24,6 @@ class TestGroup(GroupsTestBase):
 
     def test_create(self):
         assert str(self.group) == 'my group'
-        assert self.group.id == 1
         assert str(self.group.logo) == 'groups/1/logo.png'
 
     def test_get_directory(self):

--- a/groups/tests/test_views.py
+++ b/groups/tests/test_views.py
@@ -24,10 +24,11 @@ class TestGroup(GroupsTestBase):
         r = self.client.get(reverse(
             'groups:group', kwargs={'g_id': self.group.id}
         ))
+        assert self.group.id == 1
         assert r.status_code == 200
 
     def test_get_not_found(self):
-        r = self.client.get(reverse('groups:group', kwargs={'g_id': 2}))
+        r = self.client.get(reverse('groups:group', kwargs={'g_id': 3}))
         assert r.status_code == 404
 
     def test_get_zero(self):

--- a/groups/views.py
+++ b/groups/views.py
@@ -1,5 +1,7 @@
 """The views of the users app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from django.http import Http404
@@ -15,7 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 @cache_control(max_age=7200)
-def all_groups(request: 'HttpRequest') -> 'HttpResponse':
+def all_groups(request: HttpRequest) -> HttpResponse:
     """
      View that serves a page with all the groups.
 
@@ -32,7 +34,7 @@ def all_groups(request: 'HttpRequest') -> 'HttpResponse':
 
 
 @cache_control(max_age=7200)
-def group(request: 'HttpRequest', g_id: int) -> 'HttpResponse':
+def group(request: HttpRequest, g_id: int) -> HttpResponse:
     """
      View that serves a single group's page.
 

--- a/reader/admin.py
+++ b/reader/admin.py
@@ -1,12 +1,13 @@
 """Admin models for the reader app."""
 
+from __future__ import annotations
+
 from hashlib import blake2b
 from typing import Optional, Tuple, Type
 
 from django.contrib import admin
 from django.contrib.contenttypes.admin import GenericStackedInline
 from django.db.models import Q, QuerySet
-# XXX: cannot be resolved under TYPE_CHECKING
 from django.forms.models import BaseInlineFormSet, ModelForm
 from django.forms.widgets import HiddenInput
 # XXX: cannot be resolved under TYPE_CHECKING
@@ -77,6 +78,7 @@ class PageInline(admin.TabularInline):
     fields = ('image', 'preview', 'number')
     readonly_fields = ('preview',)
 
+    @admin.display(description='')
     def preview(self, obj: Page) -> str:
         """
         Get the image of the page as an HTML ``<img>``.
@@ -86,8 +88,6 @@ class PageInline(admin.TabularInline):
         :return: An ``<img>`` tag with the page image.
         """
         return utils.img_tag(obj.image, 'preview', height=150)
-
-    preview.short_description = ''
 
 
 class ChapterAdmin(admin.ModelAdmin):
@@ -113,11 +113,9 @@ class ChapterAdmin(admin.ModelAdmin):
     actions = ('toggle_final',)
     empty_value_display = 'N/A'
 
+    @admin.display(ordering='number', description='number')
     def _number(self, obj: Chapter) -> str:
         return f'{obj.number:g}'
-
-    _number.short_description = 'number'
-    _number.admin_order_field = 'number'
 
     def preview(self, obj: Chapter) -> str:
         """
@@ -132,7 +130,8 @@ class ChapterAdmin(admin.ModelAdmin):
             return ''
         return utils.img_tag(page.image, 'preview', height=50)
 
-    def toggle_final(self, request: 'HttpRequest', queryset: 'QuerySet'):
+    @admin.display(description='Toggle status of selected chapters')
+    def toggle_final(self, request: HttpRequest, queryset: QuerySet):
         """
         Toggle the status of the selected chapters.
 
@@ -141,9 +140,7 @@ class ChapterAdmin(admin.ModelAdmin):
         """
         queryset.update(final=Q(final=False))
 
-    toggle_final.short_description = 'Toggle status of selected chapters'
-
-    def get_form(self, request: 'HttpRequest',
+    def get_form(self, request: HttpRequest,
                  obj: Optional[Chapter], **kwargs
                  ) -> ModelForm:  # pragma: no cover
         form = super().get_form(request, obj, **kwargs)
@@ -152,7 +149,7 @@ class ChapterAdmin(admin.ModelAdmin):
                 Series.objects.filter(manager_id=request.user.id)
         return form
 
-    def has_change_permission(self, request: 'HttpRequest', obj:
+    def has_change_permission(self, request: HttpRequest, obj:
                               Optional[Chapter] = None) -> bool:
         """
         Return ``True`` if editing the object is permitted.
@@ -169,7 +166,7 @@ class ChapterAdmin(admin.ModelAdmin):
             return True
         return obj.series.manager_id == request.user.id
 
-    def has_delete_permission(self, request: 'HttpRequest', obj:
+    def has_delete_permission(self, request: HttpRequest, obj:
                               Optional[Chapter] = None) -> bool:
         """
         Return ``True`` if deleting the object is permitted.
@@ -235,7 +232,7 @@ class SeriesAdmin(admin.ModelAdmin):
     actions = ('toggle_completed',)
     empty_value_display = 'N/A'
 
-    def get_form(self, request: 'HttpRequest', obj: Optional[Series]
+    def get_form(self, request: HttpRequest, obj: Optional[Series]
                  = None, change: bool = False, **kwargs) -> ModelForm:
         form = super().get_form(request, obj, change, **kwargs)
         if 'format' in form.base_fields:
@@ -256,6 +253,7 @@ class SeriesAdmin(admin.ModelAdmin):
                 form.base_fields['manager'].widget = HiddenInput()
         return form
 
+    @admin.display(description='cover')
     def cover_image(self, obj: Series) -> str:
         """
         Get the cover of the series as an HTML ``<img>``.
@@ -266,9 +264,8 @@ class SeriesAdmin(admin.ModelAdmin):
         """
         return utils.img_tag(obj.cover, 'cover', height=75)
 
-    cover_image.short_description = 'cover'
-
-    def toggle_completed(self, request: 'HttpRequest', queryset: 'QuerySet'):
+    @admin.display(description='Toggle status of selected series')
+    def toggle_completed(self, request: HttpRequest, queryset: QuerySet):
         """
         Toggle the status of the selected series.
 
@@ -277,9 +274,7 @@ class SeriesAdmin(admin.ModelAdmin):
         """
         queryset.update(completed=Q(completed=False))
 
-    toggle_completed.short_description = 'Toggle status of selected series'
-
-    def has_change_permission(self, request: 'HttpRequest', obj:
+    def has_change_permission(self, request: HttpRequest, obj:
                               Optional[Series] = None) -> bool:
         """
         Return ``True`` if editing the object is permitted.
@@ -296,7 +291,7 @@ class SeriesAdmin(admin.ModelAdmin):
             return True
         return obj.manager_id == request.user.id
 
-    def has_delete_permission(self, request: 'HttpRequest', obj:
+    def has_delete_permission(self, request: HttpRequest, obj:
                               Optional[Series] = None) -> bool:
         """
         Return ``True`` if deleting the object is permitted.
@@ -358,7 +353,7 @@ class CategoryAdmin(admin.ModelAdmin):
     list_display = ('name', 'description')
     search_fields = ('name', 'description')
 
-    def get_readonly_fields(self, request: 'HttpRequest', obj:
+    def get_readonly_fields(self, request: HttpRequest, obj:
                             Optional[Category] = None) -> Tuple:
         """
         Return the fields that cannot be changed.

--- a/reader/apps.py
+++ b/reader/apps.py
@@ -11,7 +11,7 @@ class ReaderConfig(AppConfig):
     def ready(self):
         """Register the :mod:`~reader.receivers` when the app is ready."""
         __import__('reader.receivers')
-        super(ReaderConfig, self).ready()
+        super().ready()
 
 
 __all__ = ['ReaderConfig']

--- a/reader/filters.py
+++ b/reader/filters.py
@@ -1,5 +1,7 @@
 """Custom filter backends for the API."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Dict, List
 
 from rest_framework.exceptions import ValidationError
@@ -19,17 +21,17 @@ class TitleFilter(SearchFilter):
     search_title = 'Title'
     search_description = 'Search by title.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_search_fields(self, view: 'ViewSet',
-                          request: 'Request') -> List[str]:
+    def get_search_fields(self, view: ViewSet,
+                          request: Request) -> List[str]:
         return ['title', 'aliases__name']
 
-    def get_search_terms(self, request: 'Request') -> List[str]:
+    def get_search_terms(self, request: Request) -> List[str]:
         param = request.query_params.get(self.search_param, None)
         return [] if param is None else [param.replace('\x00', '')]
 
@@ -40,17 +42,17 @@ class AuthorFilter(SearchFilter):
     search_title = 'Author'
     search_description = 'Search by author name.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_search_fields(self, view: 'ViewSet',
-                          request: 'Request') -> List[str]:
+    def get_search_fields(self, view: ViewSet,
+                          request: Request) -> List[str]:
         return ['authors__name', 'authors__aliases__name']
 
-    def get_search_terms(self, request: 'Request') -> List[str]:
+    def get_search_terms(self, request: Request) -> List[str]:
         param = request.query_params.get(self.search_param, None)
         return [] if param is None else [param.replace('\x00', '')]
 
@@ -61,17 +63,17 @@ class ArtistFilter(SearchFilter):
     search_title = 'Artist'
     search_description = 'Search by artist name.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_search_fields(self, view: 'ViewSet',
-                          request: 'Request') -> List[str]:
+    def get_search_fields(self, view: ViewSet,
+                          request: Request) -> List[str]:
         return ['artists__name', 'artists__aliases__name']
 
-    def get_search_terms(self, request: 'Request') -> List[str]:
+    def get_search_terms(self, request: Request) -> List[str]:
         param = request.query_params.get(self.search_param, None)
         return [] if param is None else [param.replace('\x00', '')]
 
@@ -80,8 +82,8 @@ class StatusFilter(BaseFilterBackend):
     """Series status filter."""
     description = 'Filter by the status.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return {
@@ -90,7 +92,7 @@ class StatusFilter(BaseFilterBackend):
             'ongoing': queryset.filter(completed=False)
         }.get(request.query_params.get('status', 'any').lower())
 
-    def get_schema_operation_parameters(self, view: 'ViewSet') -> List[Dict]:
+    def get_schema_operation_parameters(self, view: ViewSet) -> List[Dict]:
         return [{
             'name': 'status',
             'required': False,
@@ -108,8 +110,8 @@ class CategoriesFilter(BaseFilterBackend):
     """Series categories filter."""
     description = "Filter by categories. (prefix with '-' to exclude)"
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         categories = request.query_params.get('categories', '').split(',')
@@ -125,7 +127,7 @@ class CategoriesFilter(BaseFilterBackend):
             )
         return queryset
 
-    def get_schema_operation_parameters(self, view: 'ViewSet') -> List[Dict]:
+    def get_schema_operation_parameters(self, view: ViewSet) -> List[Dict]:
         return [{
             'name': 'categories',
             'required': False,
@@ -146,17 +148,17 @@ class SlugFilter(SearchFilter):
     search_title = 'Slug'
     search_description = 'Filter by the slug.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_search_fields(self, view: 'ViewSet',
-                          request: 'Request') -> List[str]:
+    def get_search_fields(self, view: ViewSet,
+                          request: Request) -> List[str]:
         return ['=slug']
 
-    def get_search_terms(self, request: 'Request') -> List[str]:
+    def get_search_terms(self, request: Request) -> List[str]:
         param = request.query_params.get(self.search_param, None)
         return [] if param is None else [param.replace('\x00', '')]
 
@@ -166,13 +168,13 @@ class SeriesSort(OrderingFilter):
     ordering_fields = ['title', 'latest_upload', 'chapter_count']
     ordering_description = "Change the sort order. ('-' means descending)"
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_schema_operation_parameters(self, view: 'ViewSet') -> List[Dict]:
+    def get_schema_operation_parameters(self, view: ViewSet) -> List[Dict]:
         params = super().get_schema_operation_parameters(view)
         params[0]['schema'].update({
             'default': 'title',
@@ -190,11 +192,11 @@ class DateFormat(BaseFilterBackend):
     """Date format filter."""
     description = 'Change the displayed date format.'
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         return queryset  # no actual filtering is performed
 
-    def get_schema_operation_parameters(self, view: 'ViewSet') -> List[Dict]:
+    def get_schema_operation_parameters(self, view: ViewSet) -> List[Dict]:
         return [{
             'name': 'date_format',
             'required': False,
@@ -214,25 +216,25 @@ class ChapterFilter(SearchFilter):
     search_title = 'Series'
     search_description = "Filter by the series slug."
 
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         return super().filter_queryset(request, queryset, view)
 
-    def get_search_fields(self, view: 'ViewSet',
-                          request: 'Request') -> List[str]:
+    def get_search_fields(self, view: ViewSet,
+                          request: Request) -> List[str]:
         return ['=series__slug']
 
-    def get_search_terms(self, request: 'Request') -> List[str]:
+    def get_search_terms(self, request: Request) -> List[str]:
         param = request.query_params.get(self.search_param, None)
         return [] if param is None else [param.replace('\x00', '')]
 
 
 class PageFilter(BaseFilterBackend):
     """Chapter pages filter."""
-    def filter_queryset(self, request: 'Request', queryset: 'QuerySet',
-                        view: 'ViewSet') -> 'QuerySet':
+    def filter_queryset(self, request: Request, queryset: QuerySet,
+                        view: ViewSet) -> QuerySet:
         if view.action != 'list':
             return queryset
         params = {'series', 'volume', 'number'}
@@ -246,7 +248,7 @@ class PageFilter(BaseFilterBackend):
             chapter__number=request.query_params['number']
         ).order_by('number')
 
-    def get_schema_operation_parameters(self, view: 'ViewSet') -> List[Dict]:
+    def get_schema_operation_parameters(self, view: ViewSet) -> List[Dict]:
         return [{
             'name': 'series',
             'required': True,

--- a/reader/models.py
+++ b/reader/models.py
@@ -1,5 +1,7 @@
 """Database models for the reader app."""
 
+from __future__ import annotations
+
 from hashlib import blake2b
 from io import BytesIO
 from os import path, remove
@@ -27,7 +29,7 @@ from MangAdventure import storage, utils, validators
 from groups.models import Group
 
 
-def _cover_uploader(obj: 'Series', name: str) -> str:
+def _cover_uploader(obj: Series, name: str) -> str:
     name = f'cover.{name.split(".")[-1]}'
     name = str(obj.get_directory() / name)
     if path.exists(name):  # pragma: no cover
@@ -132,7 +134,7 @@ class Category(models.Model):
         """Save the current instance."""
         if not self.id:
             self.id = self.name.lower()
-        super(Category, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def __str__(self) -> str:
         """
@@ -289,7 +291,7 @@ class Chapter(models.Model):
 
     def save(self, *args, **kwargs):
         """Save the current instance."""
-        super(Chapter, self).save(*args, **kwargs)
+        super().save(*args, **kwargs)
         if self.file:
             validators.zipfile_validator(self.file)
             self.unzip()
@@ -297,7 +299,7 @@ class Chapter(models.Model):
         self.series.save()
 
     @cached_property
-    def next(self) -> 'Chapter':
+    def next(self) -> Chapter:
         """Get the next chapter in the series."""
         q = Q(series_id=self.series_id) & (
             Q(volume__gt=self.volume) |
@@ -307,7 +309,7 @@ class Chapter(models.Model):
             .order_by('volume', 'number').first()
 
     @cached_property
-    def prev(self) -> 'Chapter':
+    def prev(self) -> Chapter:
         """Get the previous chapter in the series."""
         q = Q(series_id=self.series_id) & (
             Q(volume__lt=self.volume) |
@@ -450,8 +452,8 @@ class Chapter(models.Model):
             return self._tuple > other._tuple
 
         raise TypeError(
-            "'>' not supported between instances of '{}' and '{}'"
-            .format(self.__class__, other.__class__)
+            "'<' not supported between instances of " +
+            f"'{self.__class__}' and '{other.__class__}'"
         )
 
     def __lt__(self, other: Any) -> bool:
@@ -478,8 +480,8 @@ class Chapter(models.Model):
             return self._tuple < other._tuple
 
         raise TypeError(
-            "'<' not supported between instances of '{}' and '{}'"
-            .format(self.__class__, other.__class__)
+            "'<' not supported between instances of " +
+            f"'{self.__class__}' and '{other.__class__}'"
         )
 
     def __hash__(self) -> int:
@@ -603,8 +605,8 @@ class Page(models.Model):
             return self.number > other.number
 
         raise TypeError(
-            "'>' not supported between instances of '{}' and '{}'"
-            .format(self.__class__, other.__class__)
+            "'<' not supported between instances of " +
+            f"'{self.__class__}' and '{other.__class__}'"
         )
 
     def __lt__(self, other: Any) -> bool:
@@ -631,8 +633,8 @@ class Page(models.Model):
             return self.number < other.number
 
         raise TypeError(
-            "'<' not supported between instances of '{}' and '{}'"
-            .format(self.__class__, other.__class__)
+            "'<' not supported between instances of " +
+            f"'{self.__class__}' and '{other.__class__}'"
         )
 
     def __hash__(self) -> int:

--- a/reader/templates/chapter.html
+++ b/reader/templates/chapter.html
@@ -125,7 +125,6 @@
         </div>
       </section>
     {% endwith %}
-    {# <a href="../comments" id="comments" class="link"><i class="mi mi-chat"></i>Comments</a> #}
   </div>
   <div id="preload" class="no-display">
     {% for page in curr_page.preload %}

--- a/reader/templates/series.html
+++ b/reader/templates/series.html
@@ -2,7 +2,6 @@
 {% load static humanize custom_tags %}
 {% block head_extras %}
   {% if request.user.is_authenticated %}
-    <meta name="csrf-token" content="{{ csrf_token }}">
     <script src="{% static 'scripts/bookmark.js' %}"
             type="application/javascript" async></script>
   {% endif %}
@@ -111,18 +110,6 @@
         </div>
       {% endfor %}
     </div>
-    {% comment %}
-      <div id="comments">
-        <section id="comments-list">
-          {% render_comment_list for series %}
-        </section>
-        <section id="comments-form">
-          {% with next=request.path %}
-            {% render_comment_form for series %}
-          {% endwith %}
-        </section>
-      </div>
-    {% endcomment %}
   </article>
 {% endblock %}
 {% block footer %}

--- a/reader/urls.py
+++ b/reader/urls.py
@@ -24,7 +24,6 @@ urlpatterns = [
     path(_page, views.chapter_page, name='page'),
     path(f'{_slug[:-1]}.atom', feeds.ReleasesAtom(), name='series.atom'),
     path(f'{_slug[:-1]}.rss', feeds.ReleasesRSS(), name='series.rss'),
-    # path(f'{_chapter}comments/', views.chapter_comments, name='comments'),
 ]
 
 if settings.CONFIG['ALLOW_DLS']:

--- a/reader/views.py
+++ b/reader/views.py
@@ -247,16 +247,6 @@ def chapter_download(request: HttpRequest, slug: str, vol: int, num: float
     )
 
 
-# def chapter_comments(request, slug, vol, num):
-#     try:
-#         chapter = Chapter.objects.get(
-#             series__slug=slug, volume=vol, number=num
-#         )
-#     except Chapter.DoesNotExist as e:
-#         raise Http404 from e
-#     return render(request, 'comments.html', {'chapter': chapter})
-
-
 __all__ = [
     'directory', 'series', 'chapter_page',
     'chapter_redirect', 'chapter_download'

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,6 @@ import MangAdventure
 cwd = Path(__file__).parent
 
 
-def read(fname: str):
-    with open(cwd / fname) as f:
-        return f.read()
-
-
 class Develop(develop):
     def run(self):
         super().run()
@@ -31,27 +26,27 @@ setup(
     author=MangAdventure.__author__,
     maintainer=MangAdventure.__author__,
     description=MangAdventure.__doc__,
-    long_description=read('README.md'),
+    long_description=(cwd / 'README.md').read_text(),
     url='https://mangadventure.readthedocs.io',
     download_url='https://github.com/mangadventure/MangAdventure',
     keywords=['manga', 'scanlation', 'reader'],
     packages=find_packages(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     setup_requires=['wheel'],
-    install_requires=read('requirements.txt').splitlines(),
+    install_requires=(cwd / 'requirements.txt').read_text().splitlines(),
     extras_require={
-        'dev': read('dev-requirements.txt').splitlines(),
-        'docs': read('docs/requirements.txt').splitlines(),
+        'dev': (cwd / 'dev-requirements.txt').read_text().splitlines(),
+        'docs': (cwd / 'docs' / 'requirements.txt').read_text().splitlines(),
         'debug': 'django-debug-toolbar',
         'mysql': 'mysqlclient',
         'pgsql': 'psycopg2',
         'csp': 'django-csp>=3.7',
         'uwsgi': 'uwsgi',
-        'sentry': 'sentry-sdk>=1.1.0',
+        'sentry': 'sentry-sdk~=1.5',
     },
     entry_points={
         'console_scripts': [
-            'mangadventure = MangAdventure.__main__:main'
+            'mangadventure = MangAdventure.__main__:run'
         ]
     },
     cmdclass={'develop': Develop},
@@ -66,10 +61,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Internet :: WWW/HTTP :: '
         'Dynamic Content :: Content Management System',

--- a/static/scripts/bookmark.js
+++ b/static/scripts/bookmark.js
@@ -2,11 +2,9 @@
   buttons.forEach(btn => {
     btn.addEventListener('click', () => {
       const xhr = new XMLHttpRequest();
-      xhr.open('POST', btn.getAttribute('data-target'), true);
-      xhr.setRequestHeader('Content-Type',
-        'application/x-www-form-urlencoded; charset=UTF-8');
-      xhr.setRequestHeader('X-CSRFToken',
-        document.querySelector('meta[name="csrf-token"]').content);
+      const data = new FormData();
+      data.append('series', btn.dataset.series);
+      xhr.open('POST', btn.dataset.target, true);
       xhr.onload = function() {
         switch(xhr.status) {
           case 201: btn.className = 'mi mi-bookmark bookmark-btn'; break;
@@ -14,7 +12,7 @@
           default: console.error(xhr.statusText);
         }
       };
-      xhr.send(`series=${btn.getAttribute('data-series')}`);
+      xhr.send(data);
     });
   });
 })(document.querySelectorAll('.bookmark-btn'));

--- a/static/scripts/search.js
+++ b/static/scripts/search.js
@@ -14,7 +14,7 @@
   function matchQuery(q) {
     if(q.matches) {
       document.querySelectorAll('td.s-hidden').forEach((elem, i) => {
-        const n = Math.floor(i / 5) + 1;
+        const n = (i / 5 >> 0) + 1;
         switch(elem.className) {
           case 'result-people s-hidden':
             appendInfo(n, 'people', 'Author/Artist', elem.innerHTML);

--- a/static/scripts/tinymce-init.js
+++ b/static/scripts/tinymce-init.js
@@ -2,7 +2,7 @@
 
 window.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.tinymce').forEach(el => {
-    const mce_conf = JSON.parse(el.getAttribute('data-tinymce-config'));
+    const mce_conf = JSON.parse(el.dataset.tinymceConfig);
     if('replace_icons' in mce_conf) {
       const old_setup = mce_conf.setup;
       mce_conf.setup = editor => {

--- a/static/styles/_functions.scss
+++ b/static/styles/_functions.scss
@@ -1,9 +1,0 @@
-@function shadow($size, $color) {
-  @if($size == none) { @return none; }
-  $shadow: null;
-  $values: (-#{$size} 0, 0 $size, $size 0, 0 -#{$size});
-  @for $i from 1 through length($values) {
-    $shadow: append($shadow, nth($values, $i) $size $color, comma);
-  }
-  @return $shadow;
-}

--- a/static/styles/_mixins.scss
+++ b/static/styles/_mixins.scss
@@ -1,151 +1,12 @@
-@mixin selection($bg, $fg) {
-  $prefixes: '', '-moz-';
-  @each $pref in $prefixes {
-    ::#{$pref}selection {
-      background: $bg;
-      color: $fg;
-    }
-  }
-}
-
-@mixin border($color: #FFF, $width: 1px, $style: solid, $suffix: null, $important: false) {
-  $border: $width $style $color;
-  @if($important) { $border: append($border, !important); }
-  border#{$suffix}: $border;
-}
-
 @mixin size($width, $height: $width) {
   width: $width;
   height: $height;
 }
 
-@mixin fullwidth() {
-  max-width: 100% !important;
-  height: auto !important;
-}
-
-@mixin title() {
-  margin: 0 0 10px;
-  padding: 6px 8px;
-  position: relative;
-  font-size: 17px;
-  font-weight: 900;
-  text-transform: uppercase;
-  text-align: center;
-  border-radius: 3px;
-}
-
-@mixin thumbnail() {
-  float: left;
-  position: relative;
-  max-height: 125px;
-  margin-right: 5px;
-  z-index: 100;
-}
-
-@mixin box-sizing($sizing: border-box) {
-  $prefixes: '-ms-', '-webkit-', '-moz-', '';
-  @each $p in $prefixes {
-    #{$p}box-sizing: $sizing;
-  }
-}
-
-@mixin border-radius($radius: 5px) {
-  $prefixes: '-moz-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}border-radius: $radius;
-  }
-}
-
-@mixin flex-direction($direction: row) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}flex-direction: $direction;
-  }
-}
-
-@mixin justify-content($justify: space-between) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}justify-content: $justify;
-  }
-}
-
-@mixin align-items($align: center) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}align-items: $align;
-  }
-}
-
-@mixin align-self($align: center) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}align-self: $align;
-  }
-}
-
-@mixin flex-wrap($wrap: wrap) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}flex-wrap: $wrap;
-  }
-}
-
-@mixin flex($flex: none) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}flex: $flex;
-  }
-}
-
-@mixin flex-shrink($shrink: 0) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}flex-shrink: $shrink;
-  }
-}
-
-@mixin flex-grow($grow: 0) {
-  $prefixes: '-webkit-', '';
-  -ms-flex-positive: $grow;
-  @each $p in $prefixes {
-    #{$p}flex-grow: $grow;
-  }
-}
-
-@mixin flex-basis($basis: 100%) {
-  $prefixes: '-ms-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}flex-basis: $basis;
-  }
-}
-
-@mixin text-overflow($overflow: ellipsis) {
-  $prefixes: '-ms-', '';
-  @each $p in $prefixes {
-    #{$p}text-overflow: $overflow;
-  }
-}
-
 @mixin truncate() {
   overflow: hidden;
   white-space: nowrap;
-  @include text-overflow();
-}
-
-@mixin text-size-adjust($size: 100%) {
-  $prefixes: '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}text-size-adjust: $size;
-  }
-}
-
-@mixin transform($transform) {
-  $prefixes: '-ms-', '-moz-', '-webkit-', '';
-  @each $p in $prefixes {
-    #{$p}transform: unquote($transform);
-  }
+  text-overflow: ellipsis;
 }
 
 @mixin touch($selector: null) {
@@ -154,4 +15,9 @@
   &:focus#{$selector} {
     @content;
   }
+}
+
+@mixin shadow($size, $color, $type: 'text') {
+  #{$type}-shadow: -#{$size} 0 $size $color,
+    0 $size $size $color, $size 0 $size $color, 0 -#{$size} $size $color;
 }

--- a/static/styles/chapter.scss
+++ b/static/styles/chapter.scss
@@ -69,7 +69,7 @@
   width: 100%;
   display: flex;
   margin: 2.5vh auto 1vh;
-  @include flex-direction(column);
+  flex-direction: column;
   .curr-page {
     font-size: 1.25em;
     margin: auto 0;
@@ -82,7 +82,7 @@
   &-top, &-bottom {
     width: 100%;
     display: inline-flex;
-    @include justify-content(space-around);
+    justify-content: space-around;
   }
 }
 

--- a/static/styles/noscript.css
+++ b/static/styles/noscript.css
@@ -2,19 +2,6 @@
 #placeholder { display: none !important }
 #page-image { display: block !important }
 #dropdowns, #controls { display: block !important }
-/* #comments form { text-align: center }
-#comments .tinymce {
-  background-color: inherit;
-  color: inherit;
-  width: 100%;
-  padding: 2px 4px;
-  border-radius: 3px;
-}
-#comments .button {
-  margin-top: 0.2em;
-  padding: 2px 4px;
-  border-radius: 3px;
-} */
 
 @media screen and (max-width: 690px) {
   #search .s-hidden { display: inline !important }

--- a/static/styles/style.scss
+++ b/static/styles/style.scss
@@ -1,5 +1,4 @@
 @import 'variables';
-@import 'functions';
 @import 'mixins';
 
 body {
@@ -9,8 +8,8 @@ body {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  -webkit-text-size-adjust: 100%;
   font-family: quote(#{$font-family}), 'Helvetica', 'Arial', sans-serif;
-  @include text-size-adjust();
 }
 
 a {
@@ -49,17 +48,6 @@ button {
   cursor: pointer;
 }
 
-thead {
-  cursor: pointer;
-  th {
-    .mi { margin: 0 }
-    .mi::before { content: quote('\f107') } // mi-down
-    &[data-sort-default] .mi, &[aria-sort='ascending'] .mi {
-      @include transform('rotate(-180deg)');
-    }
-  }
-}
-
 :focus { outline: none }
 
 ::-moz-focus-inner { border: 0 }
@@ -67,13 +55,8 @@ thead {
 #header {
   background-color: $alter-bg;
   display: flex;
+  flex: none;
   height: 45px;
-  @include flex();
-  li { border: none }
-  .navig-link {
-    color: $main-fg;
-    &:hover, &:active { color: $alter-fg }
-  }
 }
 
 #home {
@@ -97,16 +80,21 @@ thead {
     padding: 0;
     margin: 0;
     display: block;
-    li {
+    > li {
       float: left;
+      border: none;
       margin: 0.25em 0;
-      @include border-radius(3px);
+      border-radius: 3px;
     }
   }
   .navig-link {
     display: inline-block;
     padding: 8px;
-    &:hover { text-decoration: none }
+    color: $main-fg;
+    @include touch() {
+      color: $alter-fg;
+      text-decoration: none;
+    }
   }
   .dropdown {
     a {
@@ -134,9 +122,7 @@ thead {
       width: 100%;
       float: right;
       margin: 0.1em 0;
-      @include touch() {
-        color: $alter-fg;
-      }
+      @include touch() { color: $alter-fg }
     }
     &-title { padding: 4px }
   }
@@ -146,7 +132,7 @@ thead {
   display: block;
   text-align: center;
   margin: 5px;
-  @include flex();
+  flex: none;
   .text {
     font-size: 13px;
     padding-right: 6px;
@@ -162,7 +148,7 @@ thead {
   margin-left: 3px;
   padding: 4px;
   border-color: transparent;
-  @include border-radius(5px);
+  border-radius: 5px;
 }
 
 #messages {
@@ -180,15 +166,15 @@ thead {
   margin: 10px auto;
   width: 95vw;
   display: table;
-  @include flex(1 0 auto);
-  @include box-sizing();
-  article {
+  flex: 1 0 auto;
+  box-sizing: border-box;
+  > article {
     background-color: $main-bg;
     border-radius: 5px;
     padding: 0 5px;
     margin-top: 5px;
   }
-  h1 { padding: 2px 0 }
+  > h1 { padding: 2px 0 }
   h2 a {
     display: inline-block;
     color: inherit;
@@ -201,9 +187,9 @@ thead {
     display: block;
     vertical-align: top;
     &-info {
+      flex: 1;
       display: flex;
-      @include flex(1);
-      @include justify-content(space-between);
+      justify-content: space-between;
       .chapter-metadata { max-width: 40vw }
     }
     &-link {
@@ -217,18 +203,17 @@ thead {
 
 #list {
   display: flex;
-  @include justify-content(flex-start);
-  @include flex-direction(column);
+  flex-direction: column;
+  justify-content: flex-start;
   .series {
     margin-bottom: 3px;
     padding: 10px 0 0;
     width: 100%;
     .cover {
+      float: left;
       max-width: 300px;
       max-height: 300px;
-      width: auto;
-      height: 100%;
-      float: left;
+      @include size(auto, 100%);
     }
     &-info {
       display: block;
@@ -237,10 +222,10 @@ thead {
       left: 0.3em;
     }
     &-chapter {
+      flex: 1;
       display: flex;
       max-width: 90vw;
       padding: 0 0.5em;
-      @include flex(1);
       .chapter-metadata { width: 50% }
       > a {
         width: 50%;
@@ -259,23 +244,16 @@ thead {
 
 #series {
   display: flex;
-  @include flex-wrap();
-  div {
-    &.alias, &.author, &.artist, &.category {
-      text-indent: 0.5em;
-      @include truncate();
-    }
-  }
+  flex-wrap: wrap;
   h3 { margin: 0.5em 0 }
   .cover {
-    max-width: 300px;
-    max-height: 300px;
-    width: auto;
-    height: 100%;
     position: relative;
     left: -0.3em;
     float: left;
-    @include border-radius();
+    border-radius: 5px;
+    max-width: 300px;
+    max-height: 300px;
+    @include size(auto, 100%);
   }
   .bookmark-btn {
     color: $alter-fg;
@@ -294,11 +272,14 @@ thead {
   }
   &-aliases, &-authors, &-artists, &-categories {
     max-width: 55vw;
-    @include truncate();
+    > div {
+      text-indent: 0.5em;
+      @include truncate();
+    }
   }
   &-desc {
     width: 100%;
-    p {
+    > div > p {
       max-width: 90vw;
       margin: 0;
       padding: 0 0.5em;
@@ -324,11 +305,11 @@ thead {
 
 #all-groups {
   display: flex;
-  @include flex(0 1 auto);
-  @include flex-wrap();
-  @include flex-direction();
-  @include align-items();
-  @include justify-content(space-around);
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
   .group {
     padding: 0.25em;
     &-name {
@@ -339,12 +320,14 @@ thead {
     &-logo {
       display: inline-flex;
       @include size(150px);
-      img {
+      > img {
+        align-self: center;
         border-radius: 5px;
-        @include size(100%, auto);
-        @include align-self();
+        max-width: 300px;
+        max-height: 300px;
+        @include size(auto, 100%);
       }
-      svg { fill: $main-fg }
+      > svg { fill: $main-fg }
     }
   }
 }
@@ -352,13 +335,16 @@ thead {
 #group {
   &-info {
     display: flex;
-    img {
+    > img {
+      max-width: 300px;
+      max-height: 300px;
+      align-self: start;
       margin-left: -5px;
       margin-right: 5px;
       border-top-left-radius: 5px;
-      @include align-self(start);
+      @include size(auto, 100%);
     }
-    svg {
+    > svg {
       fill: $main-fg;
       margin-right: 5px;
       border-top-left-radius: 5px;
@@ -371,7 +357,7 @@ thead {
     padding-left: 0.5em;
     padding-bottom: 1em;
     &-name { color: $alter-bg }
-    div { padding-left: 0.5em }
+    > div { padding-left: 0.5em }
   }
 }
 
@@ -388,23 +374,31 @@ thead {
   text-align: center;
   border-collapse: separate;
   border-spacing: 0;
-  @include box-sizing();
-  @include border($alter-fg, 2px);
-  @include border-radius(3px);
-  th, td {
-    padding: 0.1em 0.2em;
-    &:not(:last-child) {
-      @include border($alter-fg, 2px, $suffix: '-right');
+  border-radius: 3px;
+  box-sizing: border-box;
+  border: 2px $alter-fg solid;
+  thead {
+    cursor: pointer;
+    > tr > th {
+      .mi { margin: 0 }
+      .mi::before { content: quote('\f107') } // mi-down
+      &[data-sort-default] .mi, &[aria-sort='ascending'] .mi {
+        transform: rotate(-180deg);
+      }
     }
   }
-  td { @include border($alter-fg, 2px, $suffix: '-top'); }
+  th, td {
+    padding: 0.1em 0.2em;
+    &:not(:last-child) { border-right: 2px $alter-fg solid }
+  }
+  td { border-top: 2px $alter-fg solid }
 }
 
 #bookmarks {
   .bookmark {
     display: flex;
+    flex-wrap: wrap;
     padding: 0.5em;
-    @include flex-wrap();
     .cover {
       display: block;
       max-width: 30vw;
@@ -437,24 +431,6 @@ thead {
   &-bio div { text-indent: 1em }
 }
 
-/* #comments {
-  width: 100%;
-  &-links {
-    padding-top: 0.3em;
-    text-align: center;
-  }
-  &-form {
-    form {
-      margin: 0 auto;
-      max-width: 95%;
-      padding-bottom: 0.3em;
-    }
-    .tinymce, .button {
-      border: 1px solid $alter-fg;
-    }
-  }
-} */
-
 #oauth {
   .provider {
     text-decoration: unset;
@@ -472,7 +448,8 @@ thead {
 }
 
 #user-edit .field {
-  input, textarea {
+  > input,
+  > textarea {
     width: 270px;
   }
 }
@@ -495,7 +472,7 @@ thead {
     > div:first-of-type { padding-top: 5px }
     > div:last-of-type { padding-bottom: 5px }
   }
-  form {
+  > form {
     padding: 3px 0 5px;
     label {
       display: block;
@@ -528,7 +505,7 @@ thead {
   padding: 4px;
   line-height: 1.1em;
   position: relative;
-  @include box-sizing();
+  box-sizing: border-box;
   @include touch() {
     border-bottom: none;
     border-bottom-left-radius: 0;
@@ -538,7 +515,7 @@ thead {
       display: block;
     }
   }
-  a[href='#'] { text-decoration: unset }
+  > a[href='#'] { text-decoration: unset }
   > span { cursor: pointer }
   &-list {
     display: none;
@@ -568,7 +545,7 @@ thead {
     border-radius: 5px;
     width: 200%;
     text-align: center;
-    @include transform('translateX(-50%)');
+    transform: translateX(-50%);
   }
 }
 
@@ -576,7 +553,7 @@ thead {
   max-width: 100%;
   height: auto;
   margin: auto;
-  @include box-sizing();
+  box-sizing: border-box;
 }
 
 .end::before {
@@ -598,8 +575,8 @@ thead {
 .separator {
   display: block;
   margin: auto;
-  @include border-radius(100px);
-  @include box-sizing();
+  box-sizing: border-box;
+  border-radius: 100px;
   @include size(99%, 0.5vh);
   &:last-of-type { display: none }
 }
@@ -630,14 +607,12 @@ thead {
   &-widget, &-widget *, &-reset {
     background-color: $main-bg !important;
     color: $main-fg !important;
-    font-family: quote(#{$font-family}), 'Helvetica', 'Arial', sans-serif !important;
     vertical-align: middle !important;
+    font-family: quote(#{$font-family}), 'Helvetica', 'Arial', sans-serif !important;
   }
   &-menu-item {
     color: $main-fg !important;
-    @include touch() {
-      background-color: $alter-bg !important;
-    }
+    @include touch() { background-color: $alter-bg !important }
   }
   &-btn {
     button { color: $main-fg !important }
@@ -645,14 +620,10 @@ thead {
       border-left: none !important;
       border-radius: 0 !important;
     }
-    @include touch() {
-      border-color: $alter-bg !important;
-    }
+    @include touch() { border-color: $alter-bg !important }
   }
   &-open {
-    @include touch() {
-      border-color: $alter-bg !important;
-    }
+    @include touch() { border-color: $alter-bg !important }
   }
   &-tooltip {
     color: $main-fg !important;
@@ -696,7 +667,7 @@ thead {
 
 .alter-fg { color: $alter-fg }
 
-.text-shadow { text-shadow: shadow(1px, $shadow-color); }
+.text-shadow { @include shadow(1px, $shadow-color); }
 
 .flatpage { margin-bottom: -1em }
 
@@ -729,7 +700,7 @@ thead {
           cursor: pointer;
           padding: 2px 4px;
           border: 2px solid $alter-bg;
-          @include border-radius(3px);
+          border-radius: 3px;
         }
         &:checked + label {
           border-color: $alter-fg;
@@ -744,7 +715,7 @@ thead {
   &-submit {
     padding: 3px 5px;
     border: 2px solid $alter-bg;
-    @include border-radius(3px);
+    border-radius: 3px;
     &:focus { border-color: $alter-fg }
   }
   &-results {
@@ -772,9 +743,6 @@ thead {
     .mi { margin: 0 }
   }
 }
-
-
-i[data-pcount='100+'] { padding: 0 0.5em }
 
 @media screen and (max-width: 1024px) {
   #header, #logo { height: 38px }
@@ -822,14 +790,14 @@ i[data-pcount='100+'] { padding: 0 0.5em }
     background-color: inherit !important;
     border: none !important;
     margin: 5px auto;
-    h1 {
+    > h1 {
       display: table;
       margin: auto;
       padding: 1px 4px;
       vertical-align: middle;
       max-width: 80vw;
       hyphens: auto;
-      @include border-radius();
+      border-radius: 5px;
     }
   }
   #latest {
@@ -886,13 +854,13 @@ i[data-pcount='100+'] { padding: 0 0.5em }
         display: flex;
         flex-direction: column-reverse;
         max-width: unset;
-        span {
+        > span {
           display: block;
           padding: 0.1em 1em 0;
           white-space: normal;
           height: auto;
           overflow: unset;
-          @include text-overflow(unset);
+          text-overflow: unset;
         }
         .divider { display: none }
       }
@@ -903,12 +871,11 @@ i[data-pcount='100+'] { padding: 0 0.5em }
         white-space: normal;
         hyphens: auto;
         overflow: unset;
-        @include text-overflow(unset);
+        text-overflow: unset;
       }
       &:first-of-type { padding-top: 0.2em }
     }
     .bookmark-btn { margin: 0.2em 0 -0.2em 50% }
-    div.alias, div.author, div.artist, div.category { text-indent: 0 }
     &-title { padding-bottom: 3px !important }
     &-info {
       width: 100%;
@@ -925,33 +892,32 @@ i[data-pcount='100+'] { padding: 0 0.5em }
       max-width: unset;
       overflow: unset;
       white-space: normal;
-      span, div {
+      > div {
         display: block;
         padding: 0 1em;
         hyphens: manual;
+        text-indent: 0;
       }
     }
   }
-  #search {
-    label { display: block }
-  }
+  #search label { display: block }
   #group {
     text-align: center;
     &-info {
       display: block;
-      img {
+      > img {
         border-radius: 5px;
         margin: auto;
       }
       a { display: block }
     }
-    &-desc div { text-indent: 0 }
-    .member, .member div { padding-left: 0 }
+    &-desc > div { text-indent: 0 }
+    .member, .member > div { padding-left: 0 }
   }
-  #user-profile section {
+  #user-profile > section {
     display: block;
     text-align: center;
     strong { display: block }
   }
-  #links .link span { display: none }
+  #links .link > span { display: none }
 }

--- a/users/adapters.py
+++ b/users/adapters.py
@@ -1,5 +1,7 @@
 """Custom adapters for :auth:`django-allauth <advanced.html>`."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from allauth.account.adapter import DefaultAccountAdapter
@@ -12,7 +14,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class AccountAdapter(DefaultAccountAdapter):
     """Adapter for user accounts."""
-    def get_login_redirect_url(self, request: 'HttpRequest') -> str:
+    def get_login_redirect_url(self, request: HttpRequest) -> str:
         """
         Return the URL to redirect to after a successful login.
 
@@ -22,7 +24,7 @@ class AccountAdapter(DefaultAccountAdapter):
         """
         return request.GET.get('next', '/user')
 
-    def get_logout_redirect_url(self, request: 'HttpRequest') -> str:
+    def get_logout_redirect_url(self, request: HttpRequest) -> str:
         """
         Return the URL to redirect to after a successful logout.
 
@@ -35,8 +37,8 @@ class AccountAdapter(DefaultAccountAdapter):
 
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
     """Adapter for OAuth accounts."""
-    def get_connect_redirect_url(self, request: 'HttpRequest',
-                                 social_account: 'SocialAccount') -> str:
+    def get_connect_redirect_url(self, request: HttpRequest,
+                                 social_account: SocialAccount) -> str:
         """
         Return the URL to redirect to after a successful connection.
 

--- a/users/admin.py
+++ b/users/admin.py
@@ -22,9 +22,6 @@ from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
 
 from MangAdventure.filters import boolean_filter
 
-# from commentary.admin import CommentsAdmin
-# from commentary.models import Comment
-
 
 class UserTypeFilter(admin.SimpleListFilter):
     """Admin interface filter for user types."""
@@ -217,25 +214,12 @@ class OAuthAppAdmin(SocialAppAdmin):
         )
 
 
-# class UserComment(Comment):
-#     class Meta:
-#         proxy = True
-#         auto_created = True
-#         app_label = 'users'
-
-
-# class UserCommentAdmin(CommentsAdmin):
-#     def has_add_permission(self, request):
-#         return False
-
-
 admin.site.unregister((
     EmailAddress, SocialAccount, SocialToken,
     SocialApp, models.User, models.Group
 ))
 admin.site.register(User, UserAdmin)
 admin.site.register(OAuthApp, OAuthAppAdmin)
-# admin.site.register(UserComment, UserCommentAdmin)
 
 __all__ = [
     'UserTypeFilter', 'User', 'UserForm',

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,5 +1,7 @@
 """Admin models for the users app."""
 
+from __future__ import annotations
+
 from typing import List, Tuple, Type
 
 from django.contrib import admin
@@ -9,7 +11,7 @@ from django.db.models.query import QuerySet, Value as V
 from django.forms.fields import BooleanField
 from django.forms.models import ModelForm
 from django.forms.widgets import CheckboxSelectMultiple
-# XXX: Forward reference warning when under TYPE_CHECKING
+# XXX: cannot be resolved under TYPE_CHECKING
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 from django.utils.html import format_html
@@ -31,7 +33,7 @@ class UserTypeFilter(admin.SimpleListFilter):
     #: The filter's query parameter.
     parameter_name = 'type'
 
-    def lookups(self, request: 'HttpRequest', model_admin:
+    def lookups(self, request: HttpRequest, model_admin:
                 Type[admin.ModelAdmin]) -> List[Tuple[str, str]]:
         """
         Return a list of lookups for this filter.
@@ -39,7 +41,6 @@ class UserTypeFilter(admin.SimpleListFilter):
         The first element in each tuple is the value of the
         query parameter. The second element is the human-readable
         name for the option that will appear in the admin sidebar.
-
 
         :param request: The original request.
         :param model_admin: An admin model object.
@@ -62,8 +63,7 @@ class UserTypeFilter(admin.SimpleListFilter):
             ('regular', 'Regular')
         ]
 
-    def queryset(self, request: 'HttpRequest', queryset:
-                 'QuerySet') -> 'QuerySet':
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
         """
         Return the filtered queryset based on
         the value provided in the query string.
@@ -138,8 +138,7 @@ class UserAdmin(admin.ModelAdmin):
     form = UserForm
     exclude = ('password', 'groups')
     list_display = (
-        'username', '_email', 'full_name',
-        'date_joined', 'is_active'
+        'username', '_email', 'full_name', 'date_joined', 'is_active'
     )
     list_editable = ('is_active',)
     search_fields = ('username', 'email', 'first_name', 'last_name')
@@ -149,6 +148,7 @@ class UserAdmin(admin.ModelAdmin):
     )
     ordering = ('username',)
 
+    @admin.display(ordering='email', description='e-mail address')
     def _email(self, obj: User) -> str:
         if not obj.email:
             return ''
@@ -157,9 +157,7 @@ class UserAdmin(admin.ModelAdmin):
             ' target="_blank">{0}</a>', obj.email
         )
 
-    _email.short_description = 'e-mail address'
-    _email.admin_order_field = 'email'
-
+    @admin.display(ordering=C('first_name', V(' '), 'last_name'))
     def full_name(self, obj: User) -> str:
         """
         Get the full name of the user.
@@ -170,9 +168,7 @@ class UserAdmin(admin.ModelAdmin):
         """
         return obj.get_full_name()
 
-    full_name.admin_order_field = C('first_name', V(' '), 'last_name')
-
-    def has_add_permission(self, request: 'HttpRequest') -> bool:
+    def has_add_permission(self, request: HttpRequest) -> bool:
         """
         Return whether adding an ``User`` object is permitted.
 
@@ -210,6 +206,7 @@ class OAuthAppAdmin(SocialAppAdmin):
         form.base_fields['sites'].widget.widget = CheckboxSelectMultiple()
         return form
 
+    @admin.display(ordering='provider', description='provider')
     def _provider(self, obj: OAuthApp) -> str:
         if not obj.provider:
             return ''
@@ -218,9 +215,6 @@ class OAuthAppAdmin(SocialAppAdmin):
             'https://django-allauth.readthedocs.io/en/stable/providers.html#',
             obj.provider, obj.provider.capitalize()
         )
-
-    _provider.short_description = 'provider'
-    _provider.admin_order_field = 'provider'
 
 
 # class UserComment(Comment):

--- a/users/api.py
+++ b/users/api.py
@@ -1,5 +1,7 @@
 """API viewsets for the users app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List
 
 from django.urls import reverse
@@ -44,10 +46,10 @@ class BookmarkViewSet(mixins.ListModelMixin, mixins.CreateModelMixin,
             return []
         return super().get_permissions()
 
-    def get_queryset(self) -> 'QuerySet':
+    def get_queryset(self) -> QuerySet:
         return self.request.user.bookmarks.all()
 
-    def list(self, request: 'Request', *args, **kwargs) -> Response:
+    def list(self, request: Request, *args, **kwargs) -> Response:
         token = request.user.profile.token
         rss = request.build_absolute_uri(
             reverse('user_bookmarks.rss') + '?token=' + token
@@ -133,7 +135,7 @@ class ApiKeyViewSet(mixins.CreateModelMixin, CORSMixin, GenericViewSet):
     serializer_class = AuthTokenSerializer
     permission_classes = ()
 
-    def create(self, request: 'Request', *args, **kwargs) -> Response:
+    def create(self, request: Request, *args, **kwargs) -> Response:
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']

--- a/users/apps.py
+++ b/users/apps.py
@@ -11,7 +11,7 @@ class UsersConfig(AppConfig):
     def ready(self):
         """Register the :mod:`~users.receivers` when the app is ready."""
         __import__('users.receivers')
-        super(UsersConfig, self).ready()
+        super().ready()
 
 
 __all__ = ['UsersConfig']

--- a/users/backends.py
+++ b/users/backends.py
@@ -1,5 +1,7 @@
 """Custom authentication backends."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.contrib.auth.backends import ModelBackend
@@ -11,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class ScanlationBackend(ModelBackend):
     """Authentication backend with scanlator permissions."""
     @staticmethod
-    def is_scanlator(user_obj: 'User') -> bool:
+    def is_scanlator(user_obj: User) -> bool:
         """
         Check whether the given user is a scanlator.
 
@@ -21,7 +23,7 @@ class ScanlationBackend(ModelBackend):
         """
         return user_obj.groups.filter(name='Scanlator').exists()
 
-    def has_perm(self, user_obj: 'User', perm: str,
+    def has_perm(self, user_obj: User, perm: str,
                  obj: Optional[Any] = None) -> bool:
         if not user_obj.is_active:
             return False

--- a/users/models.py
+++ b/users/models.py
@@ -1,5 +1,7 @@
 """Database models for the users app."""
 
+from __future__ import annotations
+
 from hashlib import blake2b
 from pathlib import PurePath
 from secrets import token_hex
@@ -14,7 +16,7 @@ from MangAdventure import storage, validators
 from reader.models import Series
 
 
-def _avatar_uploader(obj: 'UserProfile', name: str) -> str:
+def _avatar_uploader(obj: UserProfile, name: str) -> str:
     name = f'avatar.{name.split(".")[-1]}'
     return str(obj.get_directory() / name)
 

--- a/users/receivers.py
+++ b/users/receivers.py
@@ -1,9 +1,11 @@
 """Signal receivers for the users app."""
 
+from __future__ import annotations
+
 from typing import Type
 
 from django.dispatch import receiver
-# XXX: Forward reference warning when under TYPE_CHECKING
+# XXX: cannot be resolved under TYPE_CHECKING
 from django.http import HttpRequest
 
 from allauth.account.models import EmailAddress
@@ -11,7 +13,7 @@ from allauth.account.signals import email_confirmed
 
 
 @receiver(email_confirmed)
-def update_user_email(sender: Type[EmailAddress], request: 'HttpRequest',
+def update_user_email(sender: Type[EmailAddress], request: HttpRequest,
                       email_address: EmailAddress, **kwargs):
     """
     Receive a signal when an email address is updated and confirmed.
@@ -28,8 +30,8 @@ def update_user_email(sender: Type[EmailAddress], request: 'HttpRequest',
     email_address.set_as_primary()
     # Get rid of old email addresses
     EmailAddress.objects.filter(
-        user=email_address.user
-    ).exclude(primary=True).delete()
+        user=email_address.user, primary=False
+    ).delete()
 
 
 __all__ = ['update_user_email']

--- a/users/templates/bookmarks.html
+++ b/users/templates/bookmarks.html
@@ -13,7 +13,7 @@
   <article id="bookmarks">
     {% for release in releases %}
         <section class="bookmark">
-          <img class="cover" src="{{ release.series.cover.url }}">
+          <img class="cover" alt="Cover" src="{{ release.series.cover.url }}">
           <div class="bookmark-release">
             <h2 class="bookmark-series">
               <a href="{{ release.series.get_absolute_url }}" title="{{ release.series }}">

--- a/users/templates/edit_user.html
+++ b/users/templates/edit_user.html
@@ -18,7 +18,6 @@
       <div class="error">{{ error }}</div>
     {% endfor %}
     <form action="{% url 'user_edit' %}" method="POST" enctype="multipart/form-data">
-      {% csrf_token %}
       {% for hidden in form.hidden_fields %}{{ hidden }}{% endfor %}
       {% for field in form.visible_fields %}
         <div class="field">

--- a/users/templatetags/user_tags.py
+++ b/users/templatetags/user_tags.py
@@ -1,26 +1,27 @@
 """Template tags of the users app."""
 
-from operator import attrgetter
-from typing import Iterable, List
+from typing import List
 
 from django.template.defaultfilters import register
 
 from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.providers import registry
+from allauth.socialaccount.templatetags.socialaccount import (
+    provider_login_url as _provider_login_url
+)
 
 
-@register.filter
-def available(providers: Iterable[SocialApp]) -> List[SocialApp]:
-    """
-    Filter out the unavailable OAuth providers.
-
-    :param providers: The original list of OAuth providers.
-
-    :return: A list of available OAuth providers.
-    """
-    ids = list(map(attrgetter('id'), providers))
-    objects = SocialApp.objects \
-        .filter(provider__in=ids).values_list('provider', flat=True)
-    return list(filter(lambda p: p.id in objects, providers))
+@register.simple_tag
+def get_oauth_providers() -> List:
+    """Get a list of available OAuth providers."""
+    registry.load()
+    return [
+        registry.provider_map[p](None) for p in
+        SocialApp.objects.values_list('provider', flat=True)
+    ]
 
 
-__all__ = ['available']
+# :func:`allauth.socialaccount.templatetags.socialaccount.provider_login_url`
+provider_login_url = register.tag(_provider_login_url)
+
+__all__ = ['get_oauth_providers', 'provider_login_url']

--- a/users/tests/test_tags.py
+++ b/users/tests/test_tags.py
@@ -1,21 +1,16 @@
-from allauth.socialaccount import providers
 from allauth.socialaccount.models import SocialApp
 
-from users.templatetags.user_tags import available
+from users.templatetags.user_tags import get_oauth_providers
 
 from . import UsersTestBase
 
 
 class TestAvailableSocialApps(UsersTestBase):
     def test_empty(self):
-        all_providers = providers.registry.get_list()
-        available_providers = available(all_providers)
-        assert not available_providers
+        assert not get_oauth_providers()
 
     def test_valid(self):
         SocialApp.objects.create(
             provider='discord', name='test', client_id='test'
         )
-        all_providers = providers.registry.get_list()
-        available_providers = available(all_providers)
-        assert len(available_providers) == 1
+        assert len(get_oauth_providers()) == 1

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,7 @@
 """The views of the users app."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.decorators import login_required
@@ -28,7 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 @login_required
 @cache_control(private=True, max_age=3600)
-def profile(request: 'HttpRequest') -> HttpResponse:
+def profile(request: HttpRequest) -> HttpResponse:
     """
     View that serves the profile page of a user.
     A :class:`UserProfile` will be created if it doesn't exist.
@@ -65,7 +67,7 @@ class EditUser(TemplateView):
     #: The template that this view will render.
     template_name = 'edit_user.html'
 
-    def setup(self, request: 'HttpRequest', *args, **kwargs):
+    def setup(self, request: HttpRequest, *args, **kwargs):
         """
         Initialize attributes shared by all view methods.
 
@@ -86,7 +88,7 @@ class EditUser(TemplateView):
             ])
             self.extra_context = {'breadcrumbs': crumbs}
 
-    def get(self, request: 'HttpRequest', *args, **kwargs) -> HttpResponse:
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Handle ``GET`` requests.
 
@@ -98,7 +100,7 @@ class EditUser(TemplateView):
         form = UserProfileForm(instance=self.profile)
         return self.render_to_response(self.get_context_data(form=form))
 
-    def post(self, request: 'HttpRequest', *args, **kwargs) -> HttpResponse:
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Handle ``POST`` requests.
 
@@ -141,7 +143,7 @@ class Bookmarks(TemplateView):
     #: The template that this view will render.
     template_name = 'bookmarks.html'
 
-    def get(self, request: 'HttpRequest', *args, **kwargs) -> HttpResponse:
+    def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Handle ``GET`` requests.
 
@@ -165,7 +167,7 @@ class Bookmarks(TemplateView):
             releases=chapters, breadcrumbs=crumbs, token=token
         ))
 
-    def post(self, request: 'HttpRequest', *args, **kwargs) -> HttpResponse:
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         """
         Handle ``POST`` requests.
 


### PR DESCRIPTION
## Description

* Dropped support for Python 3.6 since it's reaching EOL in 3 weeks.
* Replaced admin method attributes with [`@admin.display`][admin].
* Replaced custom auto-increment for `Group.id` with [`SmallAutoField`][SAF].
* Replaced `available(providers)` with `get_oauth_providers()`.
* Removed the CSRF token in favour of [`Same-Site` cookies ][CSRF].
* Removed unnecessary SCSS mixins & fixed `img` styles.
* Replaced `.getAttribute` with `.dataset` in JS scripts.

[admin]: https://docs.djangoproject.com/en/3.2/ref/contrib/admin/#django.contrib.admin.display
[SAF]: https://docs.djangoproject.com/en/3.2/ref/models/fields/#smallautofield
[CSRF]: https://scotthelme.co.uk/csrf-is-dead/

## Notes

Browser compatibility changes:

- **Chrome** 49 -> 51
- **Firefox** 44 -> 60
- **Edge** 15 -> 16
- **Safari** 11 -> 14.1
- **Opera** 37 -> 39
- **iOS Safari** 11 -> 13

## Checklist

* [x] I have read the contributor guidelines.
* [x] I have documented and/or commented my code.
* [x] I have updated the docs as necessary.
* [x] I have updated the tests as necessary.
* [x] I have verified that all tests pass locally.

## Your Environment

* Python version: `3.9`
* Browser type and version: `Firefox 95.0b12`